### PR TITLE
Added possibility to influence ldap referral following. It is now possib...

### DIFF
--- a/src/main/java/org/sonar/plugins/ldap/LdapGroupsProvider.java
+++ b/src/main/java/org/sonar/plugins/ldap/LdapGroupsProvider.java
@@ -24,118 +24,140 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.security.ExternalGroupsProvider;
 import org.sonar.api.utils.SonarException;
+import org.sonar.plugins.ldap.ldapentryprocessor.LdapEntryProcessor;
 
-import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.SearchResult;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * @author Evgeny Mandrikov
  */
-public class LdapGroupsProvider extends ExternalGroupsProvider {
+public class LdapGroupsProvider extends ExternalGroupsProvider
+{
 
-  private static final Logger LOG = LoggerFactory.getLogger(LdapGroupsProvider.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LdapGroupsProvider.class);
 
-  private final Map<String, LdapContextFactory> contextFactories;
-  private final Map<String, LdapUserMapping> userMappings;
-  private final Map<String, LdapGroupMapping> groupMappings;
+    private final Map<String, LdapContextFactory> contextFactories;
+    private final Map<String, LdapUserMapping> userMappings;
+    private final Map<String, LdapGroupMapping> groupMappings;
 
-  public LdapGroupsProvider(Map<String, LdapContextFactory> contextFactories, Map<String, LdapUserMapping> userMappings, Map<String, LdapGroupMapping> groupMapping) {
-    this.contextFactories = contextFactories;
-    this.userMappings = userMappings;
-    this.groupMappings = groupMapping;
-  }
+    public LdapGroupsProvider(Map<String, LdapContextFactory> contextFactories, Map<String, LdapUserMapping> userMappings, Map<String, LdapGroupMapping> groupMapping)
+    {
+        this.contextFactories = contextFactories;
+        this.userMappings = userMappings;
+        this.groupMappings = groupMapping;
+    }
 
-  /**
-   * @throws SonarException if unable to retrieve groups
-   */
-  public Collection<String> doGetGroups(String username) {
-    checkPrerequisites(username);
-    Set<String> groups = Sets.newHashSet();
-    List<SonarException> sonarExceptions = new ArrayList<SonarException>();
-    for (String serverKey : userMappings.keySet()) {
-      if (!groupMappings.containsKey(serverKey)) {
-        // No group mapping for this ldap instance.
-        continue;
-      }
-      SearchResult searchResult = searchUserGroups(username, sonarExceptions, serverKey);
+    /**
+     * @throws SonarException if unable to retrieve groups
+     */
+    public Collection<String> doGetGroups(String username)
+    {
+        checkPrerequisites(username);
+        Set<String> groups = Sets.newHashSet();
+        List<SonarException> sonarExceptions = new ArrayList<SonarException>();
+        for (String serverKey : userMappings.keySet())
+        {
+            if (!groupMappings.containsKey(serverKey))
+            {
+                // No group mapping for this ldap instance.
+                continue;
+            }
+            SearchResult searchResult = searchUserGroups(username, sonarExceptions, serverKey);
 
-      if (searchResult != null) {
-        try {
-          NamingEnumeration<SearchResult> result = groupMappings
-            .get(serverKey)
-            .createSearch(contextFactories.get(serverKey), searchResult).find();
-          groups.addAll(mapGroups(serverKey, result));
-          // if no exceptions occur, we found the user and his groups and mapped his details.
-          break;
-        } catch (NamingException e) {
-          // just in case if Sonar silently swallowed exception
-          LOG.debug(e.getMessage(), e);
-          sonarExceptions.add(new SonarException("Unable to retrieve groups for user " + username + " in " + serverKey, e));
+            if (searchResult != null)
+            {
+                try
+                {
+                    LdapSearch ldapSearch = groupMappings
+                            .get(serverKey)
+                            .createSearch(contextFactories.get(serverKey), searchResult);
+                    groups.addAll(mapGroups(serverKey, ldapSearch));
+                    // if no exceptions occur, we found the user and his groups and mapped his details.
+                    break;
+                }
+                catch (NamingException e)
+                {
+                    // just in case if Sonar silently swallowed exception
+                    LOG.debug(e.getMessage(), e);
+                    sonarExceptions.add(new SonarException("Unable to retrieve groups for user " + username + " in " + serverKey, e));
+                }
+            }
+            else
+            {
+                // user not found
+                continue;
+            }
         }
-      } else {
-        // user not found
-        continue;
-      }
+        checkResults(groups, sonarExceptions);
+        return groups;
     }
-    checkResults(groups, sonarExceptions);
-    return groups;
-  }
 
-  private void checkResults(Set<String> groups, List<SonarException> sonarExceptions) {
-    if (groups.isEmpty() && !sonarExceptions.isEmpty()) {
-      // No groups found and there is an exception so there is a reason the user could not be found.
-      throw sonarExceptions.iterator().next();
+    private void checkResults(Set<String> groups, List<SonarException> sonarExceptions)
+    {
+        if (groups.isEmpty() && !sonarExceptions.isEmpty())
+        {
+            // No groups found and there is an exception so there is a reason the user could not be found.
+            throw sonarExceptions.iterator().next();
+        }
     }
-  }
 
-  private void checkPrerequisites(String username) {
-    if (userMappings.isEmpty() || groupMappings.isEmpty()) {
-      throw new SonarException("Unable to retrieve details for user " + username + ": No user or group mapping found.");
+    private void checkPrerequisites(String username)
+    {
+        if (userMappings.isEmpty() || groupMappings.isEmpty())
+        {
+            throw new SonarException("Unable to retrieve details for user " + username + ": No user or group mapping found.");
+        }
     }
-  }
 
-  private SearchResult searchUserGroups(String username, List<SonarException> sonarExceptions, String serverKey) {
-    SearchResult searchResult = null;
-    try {
-      LOG.debug("Requesting groups for user {}", username);
+    private SearchResult searchUserGroups(String username, List<SonarException> sonarExceptions, String serverKey)
+    {
+        SearchResult searchResult = null;
+        try
+        {
+            LOG.debug("Requesting groups for user {}", username);
 
-      searchResult = userMappings.get(serverKey).createSearch(contextFactories.get(serverKey), username)
-        .returns(groupMappings.get(serverKey).getRequiredUserAttributes())
-        .findUnique();
-    } catch (NamingException e) {
-      // just in case if Sonar silently swallowed exception
-      LOG.debug(e.getMessage(), e);
-      sonarExceptions.add(new SonarException("Unable to retrieve groups for user " + username + " in " + serverKey, e));
+            searchResult = userMappings.get(serverKey).createSearch(contextFactories.get(serverKey), username)
+                    .returns(groupMappings.get(serverKey).getRequiredUserAttributes())
+                    .findUnique();
+        }
+        catch (NamingException e)
+        {
+            // just in case if Sonar silently swallowed exception
+            LOG.debug(e.getMessage(), e);
+            sonarExceptions.add(new SonarException("Unable to retrieve groups for user " + username + " in " + serverKey, e));
+        }
+        return searchResult;
     }
-    return searchResult;
-  }
 
-  /**
-   * Map all the groups.
-   *
-   * @param serverKey The index we use to choose the correct {@link LdapGroupMapping}.
-   * @param searchResult The {@link SearchResult} from the search for the user.
-   * @return A {@link Collection} of groups the user is member of.
-   * @throws NamingException
-   */
-  private Collection<String> mapGroups(String serverKey, NamingEnumeration<SearchResult> searchResult) throws NamingException {
-    Set<String> groups = new HashSet<String>();
-    while (searchResult.hasMoreElements()) {
-      SearchResult obj = (SearchResult) searchResult.nextElement();
-      Attributes attributes = obj.getAttributes();
-      String groupId = (String) attributes.get(groupMappings.get(serverKey).getIdAttribute()).get();
-      groups.add(groupId);
+    /**
+     * Map all the groups.
+     *
+     * @param serverKey  The index we use to choose the correct {@link org.sonar.plugins.ldap.LdapGroupMapping}.
+     * @param ldapSearch
+     * @return A {@link Collection} of groups the user is member of.
+     * @throws NamingException
+     */
+    private Collection<String> mapGroups(final String serverKey, LdapSearch ldapSearch) throws NamingException
+    {
+        final Set<String> groups = new HashSet<String>();
+
+        ldapSearch.iterateSearchResults(new LdapEntryProcessor()
+        {
+            @Override
+            public void processLdapSearchResult(LdapSearchResultContext ldapSearchResultContext, Object next) throws NamingException
+            {
+                SearchResult obj = (SearchResult) next;
+                Attributes attributes = obj.getAttributes();
+                String groupId = null;
+                groupId = (String) attributes.get(groupMappings.get(serverKey).getIdAttribute()).get();
+                groups.add(groupId);
+            }
+        });
+
+        return groups;
     }
-    return groups;
-  }
 
 }

--- a/src/main/java/org/sonar/plugins/ldap/LdapReferralHandling.java
+++ b/src/main/java/org/sonar/plugins/ldap/LdapReferralHandling.java
@@ -1,0 +1,25 @@
+/*
+ * Sonar LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap;
+
+public enum LdapReferralHandling
+{
+    ALLOW_ALL,DENY_ALL,FILTERED
+}

--- a/src/main/java/org/sonar/plugins/ldap/LdapSearch.java
+++ b/src/main/java/org/sonar/plugins/ldap/LdapSearch.java
@@ -22,12 +22,21 @@ package org.sonar.plugins.ldap;
 import com.google.common.base.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonar.plugins.ldap.ldapentryprocessor.FindFirstEntryProcessor;
+import org.sonar.plugins.ldap.ldapentryprocessor.LdapEntryProcessor;
+import org.sonar.plugins.ldap.ldapentryprocessor.UniqueEntryProcessor;
+import org.sonar.plugins.ldap.ldapreferralfilter.AllowAllReferralFilter;
+import org.sonar.plugins.ldap.ldapreferralfilter.DenyAllReferralFilter;
+import org.sonar.plugins.ldap.ldapreferralfilter.DenyRegExReferralFilter;
+import org.sonar.plugins.ldap.ldapreferralfilter.LdapReferralFilter;
 
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
-import javax.naming.directory.InitialDirContext;
+import javax.naming.ReferralException;
+import javax.naming.directory.DirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
+import javax.persistence.NonUniqueResultException;
 import java.util.Arrays;
 
 /**
@@ -35,144 +44,243 @@ import java.util.Arrays;
  *
  * @author Evgeny Mandrikov
  */
-public class LdapSearch {
+public class LdapSearch
+{
 
-  private static final Logger LOG = LoggerFactory.getLogger(LdapSearch.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LdapSearch.class);
 
-  private final LdapContextFactory contextFactory;
+    private final LdapContextFactory contextFactory;
 
-  private String baseDn;
-  private int scope = SearchControls.SUBTREE_SCOPE;
-  private String request;
-  private String[] parameters;
-  private String[] returningAttributes;
+    private String baseDn;
+    private int scope = SearchControls.SUBTREE_SCOPE;
+    private String request;
+    private String[] parameters;
+    private String[] returningAttributes;
 
-  public LdapSearch(LdapContextFactory contextFactory) {
-    this.contextFactory = contextFactory;
-  }
-
-  /**
-   * Sets BaseDN.
-   */
-  public LdapSearch setBaseDn(String baseDn) {
-    this.baseDn = baseDn;
-    return this;
-  }
-
-  public String getBaseDn() {
-    return baseDn;
-  }
-
-  /**
-   * Sets the search scope.
-   *
-   * @see SearchControls#ONELEVEL_SCOPE
-   * @see SearchControls#SUBTREE_SCOPE
-   * @see SearchControls#OBJECT_SCOPE
-   */
-  public LdapSearch setScope(int scope) {
-    this.scope = scope;
-    return this;
-  }
-
-  public int getScope() {
-    return scope;
-  }
-
-  /**
-   * Sets request.
-   */
-  public LdapSearch setRequest(String request) {
-    this.request = request;
-    return this;
-  }
-
-  public String getRequest() {
-    return request;
-  }
-
-  /**
-   * Sets search parameters.
-   */
-  public LdapSearch setParameters(String... parameters) {
-    this.parameters = parameters;
-    return this;
-  }
-
-  public String[] getParameters() {
-    return parameters;
-  }
-
-  /**
-   * Sets attributes, which should be returned by search.
-   */
-  public LdapSearch returns(String... attributes) {
-    this.returningAttributes = attributes;
-    return this;
-  }
-
-  public String[] getReturningAttributes() {
-    return returningAttributes;
-  }
-
-  /**
-   * @throws NamingException if unable to perform search
-   */
-  public NamingEnumeration<SearchResult> find() throws NamingException {
-    LOG.debug("Search: {}", this);
-    NamingEnumeration<SearchResult> result;
-    InitialDirContext context = null;
-    boolean threw = false;
-    try {
-      context = contextFactory.createBindContext();
-      SearchControls controls = new SearchControls();
-      controls.setSearchScope(scope);
-      controls.setReturningAttributes(returningAttributes);
-      result = context.search(baseDn, request, parameters, controls);
-      threw = true;
-    } finally {
-      ContextHelper.close(context, threw);
+    public LdapSearch(LdapContextFactory contextFactory)
+    {
+        this.contextFactory = contextFactory;
     }
-    return result;
-  }
 
-  /**
-   * @return result, or null if not found
-   * @throws NamingException if unable to perform search, or non unique result
-   */
-  public SearchResult findUnique() throws NamingException {
-    NamingEnumeration<SearchResult> result = find();
-    if (result.hasMore()) {
-      SearchResult obj = result.next();
-      if (!result.hasMore()) {
-        return obj;
-      }
-      throw new NamingException("Non unique result for " + toString());
+    /**
+     * Sets BaseDN.
+     */
+    public LdapSearch setBaseDn(String baseDn)
+    {
+        this.baseDn = baseDn;
+        return this;
     }
-    return null;
-  }
 
-  @Override
-  public String toString() {
-    return Objects.toStringHelper(this)
-        .add("baseDn", baseDn)
-        .add("scope", scopeToString())
-        .add("request", request)
-        .add("parameters", Arrays.toString(parameters))
-        .add("attributes", Arrays.toString(returningAttributes))
-        .toString();
-  }
-
-  private String scopeToString() {
-    switch (scope) {
-      case SearchControls.ONELEVEL_SCOPE:
-        return "onelevel";
-      case SearchControls.OBJECT_SCOPE:
-        return "object";
-      case SearchControls.SUBTREE_SCOPE:
-      default:
-        return "subtree";
+    public String getBaseDn()
+    {
+        return baseDn;
     }
-  }
 
+    /**
+     * Sets the search scope.
+     *
+     * @see SearchControls#ONELEVEL_SCOPE
+     * @see SearchControls#SUBTREE_SCOPE
+     * @see SearchControls#OBJECT_SCOPE
+     */
+    public LdapSearch setScope(int scope)
+    {
+        this.scope = scope;
+        return this;
+    }
+
+    public int getScope()
+    {
+        return scope;
+    }
+
+    /**
+     * Sets request.
+     */
+    public LdapSearch setRequest(String request)
+    {
+        this.request = request;
+        return this;
+    }
+
+    public String getRequest()
+    {
+        return request;
+    }
+
+    /**
+     * Sets search parameters.
+     */
+    public LdapSearch setParameters(String... parameters)
+    {
+        this.parameters = parameters;
+        return this;
+    }
+
+    public String[] getParameters()
+    {
+        return parameters;
+    }
+
+    /**
+     * Sets attributes, which should be returned by search.
+     */
+    public LdapSearch returns(String... attributes)
+    {
+        this.returningAttributes = attributes;
+        return this;
+    }
+
+    public String[] getReturningAttributes()
+    {
+        return returningAttributes;
+    }
+
+
+    /**
+     * @return result, or null if not found
+     * @throws NamingException if unable to perform search, or non unique result
+     */
+    public SearchResult findUnique() throws NamingException
+    {
+        UniqueEntryProcessor ldapEntryProcessor = new UniqueEntryProcessor();
+
+        iterateSearchResults(ldapEntryProcessor);
+        return ldapEntryProcessor.getResult();
+    }
+
+    public SearchResult findFirst() throws NamingException
+    {
+
+        FindFirstEntryProcessor ldapEntryProcessor = new FindFirstEntryProcessor();
+
+        try
+        {
+            iterateSearchResults(ldapEntryProcessor);
+        }
+        catch (NonUniqueResultException e)
+        {
+            throw new NamingException("Non unique result for " + toString());
+        }
+
+        return (SearchResult) ldapEntryProcessor.getResult();
+    }
+
+    public void iterateSearchResults(LdapEntryProcessor ldapEntryProcessor) throws NamingException
+    {
+        LdapReferralFilter ldapReferralFilter = getReferralFilter();
+        iterateSearchResults(ldapEntryProcessor, ldapReferralFilter);
+    }
+
+    private LdapReferralFilter getReferralFilter()
+    {
+        LdapReferralHandling referralHandling = contextFactory.getReferralHandling();
+
+        switch (referralHandling)
+        {
+            case ALLOW_ALL:
+                return new AllowAllReferralFilter();
+            case DENY_ALL:
+                return new DenyAllReferralFilter();
+            case FILTERED:
+                return new DenyRegExReferralFilter(contextFactory.getReferralFilterList());
+            default:
+                throw new IllegalStateException("Unknown referralhandling");
+        }
+    }
+
+    private void iterateSearchResults(LdapEntryProcessor ldapEntryProcessor, LdapReferralFilter ldapReferralFilter) throws NamingException
+    {
+        LOG.debug("Search: {}", this);
+        DirContext context = null;
+        boolean threw = false;
+        try
+        {
+
+            // Create the initial context
+            context = contextFactory.createBindContext();
+            SearchControls controls = new SearchControls();
+            controls.setSearchScope(scope);
+            controls.setReturningAttributes(returningAttributes);
+            LdapSearchResultContext ldapSearchResultContext = new LdapSearchResultContextImpl(this);
+
+
+            // Do this in a loop because you don't know how
+            // many referrals there will be
+            for (boolean moreReferrals = true; moreReferrals; )
+            {
+                try
+                {
+                    // Perform the search
+                    NamingEnumeration answer = context.search(baseDn, request, parameters, controls);
+
+                    // Print the answer
+                    while (answer.hasMore())
+                    {
+                        ldapEntryProcessor.processLdapSearchResult(ldapSearchResultContext, answer.next());
+                        if (ldapSearchResultContext.isIteratingStopped())
+                        {
+                            return;
+                        }
+                    }
+                    // The search completes with no more referrals
+                    moreReferrals = false;
+
+                }
+                catch (ReferralException e)
+                {
+                    if (!ldapReferralFilter.followReferral(e.getReferralInfo()))
+                    {
+                        moreReferrals = e.skipReferral();
+                    }
+
+                    // Point to the new context
+                    if (moreReferrals)
+                    {
+                        context = (DirContext) e.getReferralContext();
+                    }
+                }
+            }
+
+            threw = true;
+        }
+        finally
+        {
+            ContextHelper.close(context, threw);
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return Objects.toStringHelper(this)
+                .add("baseDn", baseDn)
+                .add("scope", scopeToString())
+                .add("request", request)
+                .add("parameters", Arrays.toString(parameters))
+                .add("attributes", Arrays.toString(returningAttributes))
+                .toString();
+    }
+
+    private String scopeToString()
+    {
+        switch (scope)
+        {
+            case SearchControls.ONELEVEL_SCOPE:
+                return "onelevel";
+            case SearchControls.OBJECT_SCOPE:
+                return "object";
+            case SearchControls.SUBTREE_SCOPE:
+            default:
+                return "subtree";
+        }
+    }
+
+    public SearchResult find(SingleEntryFindMode singleEntryFindMode) throws NamingException
+    {
+        if(singleEntryFindMode ==SingleEntryFindMode.FIND_FIRST)
+            return findFirst();
+        else
+            return findUnique();
+    }
 }

--- a/src/main/java/org/sonar/plugins/ldap/LdapSearchResultContext.java
+++ b/src/main/java/org/sonar/plugins/ldap/LdapSearchResultContext.java
@@ -1,0 +1,29 @@
+/*
+ * Sonar LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap;
+
+public interface LdapSearchResultContext
+{
+    void setIteratingStopped(boolean iterratingStopped);
+
+    boolean isIteratingStopped();
+
+    public LdapSearch getLdapSearch();
+}

--- a/src/main/java/org/sonar/plugins/ldap/LdapSearchResultContextImpl.java
+++ b/src/main/java/org/sonar/plugins/ldap/LdapSearchResultContextImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Sonar LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap;
+
+public class LdapSearchResultContextImpl implements LdapSearchResultContext
+{
+    private boolean iteratingStopped =false;
+    private LdapSearch ldapSearch;
+
+    public LdapSearchResultContextImpl(LdapSearch ldapSearch)
+    {
+
+        this.ldapSearch = ldapSearch;
+    }
+
+    public void setIteratingStopped(boolean iteratingStopped)
+    {
+        this.iteratingStopped = iteratingStopped;
+    }
+
+    @Override
+    public boolean isIteratingStopped()
+    {
+        return iteratingStopped;
+
+    }
+
+    public LdapSearch getLdapSearch()
+    {
+        return ldapSearch;
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/LdapUserMapping.java
+++ b/src/main/java/org/sonar/plugins/ldap/LdapUserMapping.java
@@ -39,6 +39,7 @@ public class LdapUserMapping {
   private final String request;
   private final String realNameAttribute;
   private final String emailAttribute;
+  private final SingleEntryFindMode findMode;
 
   /**
    * Constructs mapping from Sonar settings.
@@ -67,12 +68,17 @@ public class LdapUserMapping {
       // For backward compatibility with plugin versions lower than 1.2
       LoggerFactory.getLogger(LdapGroupMapping.class)
           .warn("Properties '" + settingsPrefix + ".user.objectClass' and '" + settingsPrefix + ".user.loginAttribute' are deprecated" +
-            " and should be replaced by single property '" + settingsPrefix + ".user.request' with value: " + req);
+              " and should be replaced by single property '" + settingsPrefix + ".user.request' with value: " + req);
     } else {
       req = StringUtils.defaultString(settings.getString(settingsPrefix + ".user.request"), DEFAULT_REQUEST);
     }
     req = StringUtils.replace(req, "{login}", "{0}");
     this.request = req;
+
+    String userFindModeStr = StringUtils.defaultString(settings.getString(settingsPrefix + ".user.FindMode"), SingleEntryFindMode.FIND_UNIQUE.toString());
+    userFindModeStr = userFindModeStr.toUpperCase().trim();
+    this.findMode = SingleEntryFindMode.valueOf(userFindModeStr);
+
   }
 
   /**
@@ -117,6 +123,10 @@ public class LdapUserMapping {
     return emailAttribute;
   }
 
+  public SingleEntryFindMode getFindMode() {
+    return findMode;
+  }
+
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
@@ -124,6 +134,7 @@ public class LdapUserMapping {
         .add("request", getRequest())
         .add("realNameAttribute", getRealNameAttribute())
         .add("emailAttribute", getEmailAttribute())
+        .add("findMode", findMode)
         .toString();
   }
 

--- a/src/main/java/org/sonar/plugins/ldap/Main.java
+++ b/src/main/java/org/sonar/plugins/ldap/Main.java
@@ -1,0 +1,55 @@
+/*
+ * Sonar LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap;
+
+import org.sonar.api.config.Settings;
+
+public class Main
+{
+    static
+    {
+        System.setProperty(org.slf4j.impl.SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "TRACE");
+    }
+    public static void main(String[] args)
+    {
+
+        LdapSettingsManager settingsManager = new LdapSettingsManager(generateAuthenticationSettings(), null);
+        LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(settingsManager.getContextFactories(), settingsManager.getUserMappings());
+        ldapAuthenticator.init();
+        boolean authenticate = ldapAuthenticator.authenticate("Roettges.Florian@ads.local", "2383ThisIsSecure2383");
+        System.out.println(authenticate);
+        System.out.println(authenticate);
+    }
+
+    private static Settings generateAuthenticationSettings()
+    {
+        Settings settings = new Settings();
+
+        settings.setProperty("ldap.url", "ldap://iiv-ticket.ads.local/dc=ldap,dc=proxy")
+                .setProperty("ldap.bindDn", "cn=bind,ou=svn,dc=ldap,dc=proxy")
+                .setProperty("ldap.bindPassword", "ldapproxysvn")
+                //.setProperty("ldap.authentication", LdapContextFactory.CRAM_MD5_METHOD)
+                .setProperty("ldap.user.request","(&(objectClass=user)(userPrincipalName={login}))")
+                .setProperty("ldap.user.baseDn", "ou=svn")
+                .setProperty("ldap.user.findMode",SingleEntryFindMode.FIND_FIRST.toString())
+                .setProperty("ldap.referralHandling",LdapReferralHandling.DENY_ALL.toString());
+        return settings;
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/SingleEntryFindMode.java
+++ b/src/main/java/org/sonar/plugins/ldap/SingleEntryFindMode.java
@@ -1,0 +1,25 @@
+/*
+ * Sonar LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap;
+
+public enum SingleEntryFindMode
+{
+    FIND_FIRST,FIND_UNIQUE;
+}

--- a/src/main/java/org/sonar/plugins/ldap/ldapentryprocessor/FindFirstEntryProcessor.java
+++ b/src/main/java/org/sonar/plugins/ldap/ldapentryprocessor/FindFirstEntryProcessor.java
@@ -1,0 +1,39 @@
+/*
+ * Sonar LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.ldapentryprocessor;
+
+import org.sonar.plugins.ldap.LdapSearchResultContext;
+
+public class FindFirstEntryProcessor implements LdapEntryProcessor
+{
+    private Object result;
+
+    @Override
+    public void processLdapSearchResult(LdapSearchResultContext ldapSearchResultContext, Object next)
+    {
+        this.result = next;
+        ldapSearchResultContext.setIteratingStopped(true);
+    }
+
+    public Object getResult()
+    {
+        return result;
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/ldapentryprocessor/LdapEntryProcessor.java
+++ b/src/main/java/org/sonar/plugins/ldap/ldapentryprocessor/LdapEntryProcessor.java
@@ -1,0 +1,29 @@
+/*
+ * Sonar LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.ldapentryprocessor;
+
+import org.sonar.plugins.ldap.LdapSearchResultContext;
+
+import javax.naming.NamingException;
+
+public interface LdapEntryProcessor
+{
+    void processLdapSearchResult(LdapSearchResultContext ldapSearchResultContext, Object next) throws NamingException;
+}

--- a/src/main/java/org/sonar/plugins/ldap/ldapentryprocessor/UniqueEntryProcessor.java
+++ b/src/main/java/org/sonar/plugins/ldap/ldapentryprocessor/UniqueEntryProcessor.java
@@ -1,0 +1,48 @@
+/*
+ * Sonar LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.ldapentryprocessor;
+
+import org.sonar.plugins.ldap.LdapSearchResultContext;
+
+import javax.naming.NamingException;
+import javax.naming.directory.SearchResult;
+
+public class UniqueEntryProcessor implements LdapEntryProcessor
+{
+    private SearchResult result = null;
+    private int count = 0;
+
+    @Override
+    public void processLdapSearchResult(LdapSearchResultContext ldapSearchResultContext, Object next) throws NamingException
+    {
+        count++;
+        result = (SearchResult) next;
+
+        if (count > 1)
+        {
+            throw new NamingException("Non unique result for " + ldapSearchResultContext.getLdapSearch().toString());
+        }
+    }
+
+    public SearchResult getResult()
+    {
+        return result;
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/ldapreferralfilter/AllowAllReferralFilter.java
+++ b/src/main/java/org/sonar/plugins/ldap/ldapreferralfilter/AllowAllReferralFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Sonar LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.ldapreferralfilter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AllowAllReferralFilter implements LdapReferralFilter
+{
+    private static final Logger LOG = LoggerFactory.getLogger(AllowAllReferralFilter.class);
+
+    @Override
+    public boolean followReferral(Object referralInfo)
+    {
+        LOG.debug("following referral " + referralInfo);
+        return true;
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/ldapreferralfilter/DenyAllReferralFilter.java
+++ b/src/main/java/org/sonar/plugins/ldap/ldapreferralfilter/DenyAllReferralFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Sonar LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.ldapreferralfilter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DenyAllReferralFilter implements LdapReferralFilter
+{
+    private static final Logger LOG = LoggerFactory.getLogger(DenyAllReferralFilter.class);
+
+    @Override
+    public boolean followReferral(Object referralInfo)
+    {
+        LOG.debug("ignoring referral " + referralInfo);
+        return false;
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/ldapreferralfilter/DenyRegExReferralFilter.java
+++ b/src/main/java/org/sonar/plugins/ldap/ldapreferralfilter/DenyRegExReferralFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Sonar LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.ldapreferralfilter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class DenyRegExReferralFilter implements LdapReferralFilter
+{
+    private static final Logger LOG = LoggerFactory.getLogger(DenyRegExReferralFilter.class);
+    List<String> deniedReferrals;
+
+    public DenyRegExReferralFilter(List<String> deniedReferrals)
+    {
+        this.deniedReferrals = deniedReferrals;
+    }
+
+    @Override
+    public boolean followReferral(Object referralInfo)
+    {
+        for (String deniedReferral : deniedReferrals)
+        {
+            if (referralInfo.toString().matches(deniedReferral))
+            {
+                LOG.debug("ignoring referral " + referralInfo + " because of regex " + deniedReferral);
+                return false;
+            }
+        }
+        LOG.debug("following referral" + referralInfo);
+        return true;
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/ldapreferralfilter/LdapReferralFilter.java
+++ b/src/main/java/org/sonar/plugins/ldap/ldapreferralfilter/LdapReferralFilter.java
@@ -1,0 +1,25 @@
+/*
+ * Sonar LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.ldapreferralfilter;
+
+public interface LdapReferralFilter
+{
+    boolean followReferral(Object referralInfo);
+}

--- a/src/test/java/org/sonar/plugins/ldap/CountingEntryProcessor.java
+++ b/src/test/java/org/sonar/plugins/ldap/CountingEntryProcessor.java
@@ -1,0 +1,40 @@
+/*
+ * Sonar LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap;
+
+import org.sonar.plugins.ldap.ldapentryprocessor.LdapEntryProcessor;
+
+import javax.naming.NamingException;
+
+public class CountingEntryProcessor implements LdapEntryProcessor
+{
+    int count=0;
+
+    @Override
+    public void processLdapSearchResult(LdapSearchResultContext ldapSearchResultContext, Object next) throws NamingException
+    {
+        count++;
+    }
+
+    public int getCount()
+    {
+        return count;
+    }
+}

--- a/src/test/java/org/sonar/plugins/ldap/LdapSearchTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/LdapSearchTest.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.plugins.ldap;
 
-import com.google.common.collect.Iterators;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -29,83 +28,117 @@ import org.sonar.plugins.ldap.server.LdapServer;
 
 import javax.naming.NamingException;
 import javax.naming.directory.SearchControls;
-
 import java.util.Map;
 
 import static org.fest.assertions.Assertions.assertThat;
 
-public class LdapSearchTest {
+public class LdapSearchTest
+{
 
-  @ClassRule
-  public static LdapServer server = new LdapServer("/users.example.org.ldif");
+    @ClassRule
+    public static LdapServer server = new LdapServer("/users.example.org.ldif");
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-  private static Map<String, LdapContextFactory> contextFactories;
+    private static Map<String, LdapContextFactory> contextFactories;
 
-  @BeforeClass
-  public static void init() {
-    contextFactories = new LdapSettingsManager(LdapSettingsFactory.generateSimpleAnonymousAccessSettings(server, null), new LdapAutodiscovery()).getContextFactories();
-  }
+    @BeforeClass
+    public static void init()
+    {
+        contextFactories = new LdapSettingsManager(LdapSettingsFactory.generateSimpleAnonymousAccessSettings(server, null), new LdapAutodiscovery()).getContextFactories();
+    }
+
+    @Test
+    public void subtreeSearch() throws Exception
+    {
+        LdapSearch search = new LdapSearch(contextFactories.values().iterator().next())
+                .setBaseDn("dc=example,dc=org")
+                .setRequest("(objectClass={0})")
+                .setParameters("inetOrgPerson")
+                .returns("objectClass");
+
+        assertThat(search.getBaseDn()).isEqualTo("dc=example,dc=org");
+        assertThat(search.getScope()).isEqualTo(SearchControls.SUBTREE_SCOPE);
+        assertThat(search.getRequest()).isEqualTo("(objectClass={0})");
+        assertThat(search.getParameters()).isEqualTo(new String[]{"inetOrgPerson"});
+        assertThat(search.getReturningAttributes()).isEqualTo(new String[]{"objectClass"});
+        assertThat(search.toString()).isEqualTo("LdapSearch{baseDn=dc=example,dc=org, scope=subtree, request=(objectClass={0}), parameters=[inetOrgPerson], attributes=[objectClass]}");
+        CountingEntryProcessor countingEntryProcessor = new CountingEntryProcessor();
+        search.iterateSearchResults(countingEntryProcessor);
+        assertThat(countingEntryProcessor.getCount()).isEqualTo(3);
+        thrown.expect(NamingException.class);
+        thrown.expectMessage("Non unique result for " + search.toString());
+        search.findUnique();
+    }
+
+    @Test
+    public void oneLevelSearch() throws Exception
+    {
+        LdapSearch search = new LdapSearch(contextFactories.values().iterator().next())
+                .setBaseDn("dc=example,dc=org")
+                .setScope(SearchControls.ONELEVEL_SCOPE)
+                .setRequest("(objectClass={0})")
+                .setParameters("inetOrgPerson")
+                .returns("cn");
+
+        assertThat(search.getBaseDn()).isEqualTo("dc=example,dc=org");
+        assertThat(search.getScope()).isEqualTo(SearchControls.ONELEVEL_SCOPE);
+        assertThat(search.getRequest()).isEqualTo("(objectClass={0})");
+        assertThat(search.getParameters()).isEqualTo(new String[]{"inetOrgPerson"});
+        assertThat(search.getReturningAttributes()).isEqualTo(new String[]{"cn"});
+        assertThat(search.toString()).isEqualTo("LdapSearch{baseDn=dc=example,dc=org, scope=onelevel, request=(objectClass={0}), parameters=[inetOrgPerson], attributes=[cn]}");
+
+        CountingEntryProcessor countingEntryProcessor = new CountingEntryProcessor();
+        search.iterateSearchResults(countingEntryProcessor);
+        assertThat(countingEntryProcessor.getCount()).isEqualTo(0);
+        assertThat(search.findUnique()).isNull();
+    }
 
   @Test
-  public void subtreeSearch() throws Exception {
+  public void referralHandling() throws NamingException {
     LdapSearch search = new LdapSearch(contextFactories.values().iterator().next())
-      .setBaseDn("dc=example,dc=org")
-      .setRequest("(objectClass={0})")
-      .setParameters("inetOrgPerson")
-      .returns("objectClass");
-
-    assertThat(search.getBaseDn()).isEqualTo("dc=example,dc=org");
-    assertThat(search.getScope()).isEqualTo(SearchControls.SUBTREE_SCOPE);
-    assertThat(search.getRequest()).isEqualTo("(objectClass={0})");
-    assertThat(search.getParameters()).isEqualTo(new String[] {"inetOrgPerson"});
-    assertThat(search.getReturningAttributes()).isEqualTo(new String[] {"objectClass"});
-    assertThat(search.toString()).isEqualTo("LdapSearch{baseDn=dc=example,dc=org, scope=subtree, request=(objectClass={0}), parameters=[inetOrgPerson], attributes=[objectClass]}");
-    assertThat(Iterators.size(Iterators.forEnumeration(search.find()))).isEqualTo(3);
-    thrown.expect(NamingException.class);
-    thrown.expectMessage("Non unique result for " + search.toString());
-    search.findUnique();
-  }
-
-  @Test
-  public void oneLevelSearch() throws Exception {
-    LdapSearch search = new LdapSearch(contextFactories.values().iterator().next())
-      .setBaseDn("dc=example,dc=org")
-      .setScope(SearchControls.ONELEVEL_SCOPE)
-      .setRequest("(objectClass={0})")
-      .setParameters("inetOrgPerson")
-      .returns("cn");
+        .setBaseDn("dc=example,dc=org")
+        .setScope(SearchControls.ONELEVEL_SCOPE)
+        .setRequest("(objectClass={0})")
+        .setParameters("inetOrgPerson")
+        .returns("cn");
 
     assertThat(search.getBaseDn()).isEqualTo("dc=example,dc=org");
     assertThat(search.getScope()).isEqualTo(SearchControls.ONELEVEL_SCOPE);
     assertThat(search.getRequest()).isEqualTo("(objectClass={0})");
-    assertThat(search.getParameters()).isEqualTo(new String[] {"inetOrgPerson"});
-    assertThat(search.getReturningAttributes()).isEqualTo(new String[] {"cn"});
+    assertThat(search.getParameters()).isEqualTo(new String[]{"inetOrgPerson"});
+    assertThat(search.getReturningAttributes()).isEqualTo(new String[]{"cn"});
     assertThat(search.toString()).isEqualTo("LdapSearch{baseDn=dc=example,dc=org, scope=onelevel, request=(objectClass={0}), parameters=[inetOrgPerson], attributes=[cn]}");
-    assertThat(Iterators.size(Iterators.forEnumeration(search.find()))).isEqualTo(0);
+
+    CountingEntryProcessor countingEntryProcessor = new CountingEntryProcessor();
+    search.iterateSearchResults(countingEntryProcessor);
+    assertThat(countingEntryProcessor.getCount()).isEqualTo(0);
     assertThat(search.findUnique()).isNull();
   }
 
-  @Test
-  public void objectSearch() throws Exception {
-    LdapSearch search = new LdapSearch(contextFactories.values().iterator().next())
-      .setBaseDn("cn=bind,ou=users,dc=example,dc=org")
-      .setScope(SearchControls.OBJECT_SCOPE)
-      .setRequest("(objectClass={0})")
-      .setParameters("uidObject")
-      .returns("uid");
+    @Test
+    public void objectSearch() throws Exception
+    {
+        LdapSearch search = new LdapSearch(contextFactories.values().iterator().next())
+                .setBaseDn("cn=bind,ou=users,dc=example,dc=org")
+                .setScope(SearchControls.OBJECT_SCOPE)
+                .setRequest("(objectClass={0})")
+                .setParameters("uidObject")
+                .returns("uid");
 
-    assertThat(search.getBaseDn()).isEqualTo("cn=bind,ou=users,dc=example,dc=org");
-    assertThat(search.getScope()).isEqualTo(SearchControls.OBJECT_SCOPE);
-    assertThat(search.getRequest()).isEqualTo("(objectClass={0})");
-    assertThat(search.getParameters()).isEqualTo(new String[] {"uidObject"});
-    assertThat(search.getReturningAttributes()).isEqualTo(new String[] {"uid"});
-    assertThat(search.toString()).isEqualTo(
-      "LdapSearch{baseDn=cn=bind,ou=users,dc=example,dc=org, scope=object, request=(objectClass={0}), parameters=[uidObject], attributes=[uid]}");
-    assertThat(Iterators.size(Iterators.forEnumeration(search.find()))).isEqualTo(1);
-    assertThat(search.findUnique()).isNotNull();
-  }
+        assertThat(search.getBaseDn()).isEqualTo("cn=bind,ou=users,dc=example,dc=org");
+        assertThat(search.getScope()).isEqualTo(SearchControls.OBJECT_SCOPE);
+        assertThat(search.getRequest()).isEqualTo("(objectClass={0})");
+        assertThat(search.getParameters()).isEqualTo(new String[]{"uidObject"});
+        assertThat(search.getReturningAttributes()).isEqualTo(new String[]{"uid"});
+        assertThat(search.toString()).isEqualTo(
+                "LdapSearch{baseDn=cn=bind,ou=users,dc=example,dc=org, scope=object, request=(objectClass={0}), parameters=[uidObject], attributes=[uid]}");
+        CountingEntryProcessor countingEntryProcessor = new CountingEntryProcessor();
+        search.iterateSearchResults(countingEntryProcessor);
+        assertThat(countingEntryProcessor.getCount()).isEqualTo(1);
+        assertThat(search.findUnique()).isNotNull();
+    }
+
 
 }

--- a/src/test/java/org/sonar/plugins/ldap/LdapUserMappingTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/LdapUserMappingTest.java
@@ -38,7 +38,7 @@ public class LdapUserMappingTest {
       "baseDn=null," +
       " request=(&(objectClass=inetOrgPerson)(uid={0}))," +
       " realNameAttribute=cn," +
-      " emailAttribute=mail}");
+      " emailAttribute=mail, findMode=FIND_UNIQUE}");
   }
 
   @Test
@@ -59,7 +59,7 @@ public class LdapUserMappingTest {
       "baseDn=cn=users," +
       " request=(&(objectClass=user)(sAMAccountName={0}))," +
       " realNameAttribute=cn," +
-      " emailAttribute=mail}");
+      " emailAttribute=mail, findMode=FIND_UNIQUE}");
   }
 
   @Test

--- a/src/test/java/org/sonar/plugins/ldap/ldapreferralfilter/AllowAllReferralFilterTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/ldapreferralfilter/AllowAllReferralFilterTest.java
@@ -1,0 +1,19 @@
+package org.sonar.plugins.ldap.ldapreferralfilter; 
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AllowAllReferralFilterTest {
+
+    AllowAllReferralFilter sut = new AllowAllReferralFilter();
+
+    @Test
+    public void testFollowReferral() throws Exception {
+      String given="anyString";
+
+      boolean returned = sut.followReferral(given);
+
+      assertEquals(true, returned);
+    } 
+}

--- a/src/test/java/org/sonar/plugins/ldap/ldapreferralfilter/DenyAllReferralFilterTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/ldapreferralfilter/DenyAllReferralFilterTest.java
@@ -1,0 +1,20 @@
+package org.sonar.plugins.ldap.ldapreferralfilter; 
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class DenyAllReferralFilterTest {
+
+    DenyAllReferralFilter sut = new DenyAllReferralFilter();
+
+
+    @Test
+    public void testFollowReferral() throws Exception {
+      String given="anyString";
+
+      boolean returned = sut.followReferral(given);
+
+      assertEquals(false, returned);
+    } 
+}

--- a/src/test/java/org/sonar/plugins/ldap/ldapreferralfilter/DenyRegExReferralFilterTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/ldapreferralfilter/DenyRegExReferralFilterTest.java
@@ -1,0 +1,37 @@
+package org.sonar.plugins.ldap.ldapreferralfilter;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class DenyRegExReferralFilterTest {
+
+  DenyRegExReferralFilter sut;
+  private List<String> deniedReferrals;
+
+  @Before
+  public void setUp() throws Exception {
+    deniedReferrals = new ArrayList<>();
+  }
+
+  @Test
+  public void testBlockReferralsContainingString() throws Exception {
+    String containingString = "Block";
+    deniedReferrals.add(".*" + containingString + ".*");
+    sut = new DenyRegExReferralFilter(deniedReferrals);
+
+    boolean thisShouldBeBlocked = sut.followReferral("ThisShouldBeBlocked");
+    assertEquals(false, thisShouldBeBlocked);
+    thisShouldBeBlocked = sut.followReferral("BlockedShouldItBe");
+    assertEquals(false, thisShouldBeBlocked);
+    thisShouldBeBlocked = sut.followReferral("itshouldBlockThisString");
+    assertEquals(false, thisShouldBeBlocked);
+
+    boolean thisShouldNotBeBlocked=sut.followReferral("thisShouldBeAllowed");
+    assertEquals(true, thisShouldNotBeBlocked);
+  }
+}


### PR DESCRIPTION
...le

to either follow all,non or some specific ldap referrals. To influence
ldap referral handling the property ldap.referralHandling can be set to
DENY_ALL, ALLOW_ALL or FILTERED. Default is ALLOW_ALL to keep backward
compatibility.

If FILTERED is defined as referral handling another property is mandatory:
ldap.referralFilter which should contain a regular expression.
All referrals which match the regular expression will be ignored.

I also allowed that search results from ldap (regarding users) can now
contain multiple user objects if the property ldap.user.findMode is
set to FIND_FIRST. In that case the first user object returned by ldap is
used for authentication.
Default is FIND_UNIQUE to keep backward compatibility.
Modified and added Tests

Added Properties:
ldap.referralHandling = [DENY_ALL, ALLOW_ALL, FILTERED]
ldap.referralFilter = .*blockedreferral.com.*                              //RegEx to define blocked referrals
ldap.user.findMode = [FIND_FIRST, FIND_UNIQUE]

