### PR TITLE
Addition of Windows Authenitcation support to LDAP plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,8 @@
     <sonar.pluginName>LDAP</sonar.pluginName>
     <sonar.pluginClass>org.sonar.plugins.ldap.LdapPlugin</sonar.pluginClass>
 
+    <jna.version>4.1.0</jna.version>
+
     <version.org.apache.directory.server>1.5.5</version.org.apache.directory.server>
     <version.org.opends>2.2.0</version.org.opends>
 
@@ -73,6 +75,16 @@
       <artifactId>sonar-plugin-api</artifactId>
       <version>${sonar.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <version>${jna.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna-platform</artifactId>
+      <version>${jna.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/sonar/plugins/ldap/LdapExtensions.java
+++ b/src/main/java/org/sonar/plugins/ldap/LdapExtensions.java
@@ -1,0 +1,81 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.ExtensionProvider;
+import org.sonar.api.ServerExtension;
+import org.sonar.api.config.Settings;
+import org.sonar.plugins.ldap.windows.WindowsSecurityRealm;
+
+import java.util.List;
+
+public class LdapExtensions extends ExtensionProvider implements ServerExtension {
+    static final String SONAR_LDAP_WINDOWS_AUTH = "sonar.ldap.windows.auth";
+    static final String DEFAULT_SONAR_LDAP_WINDOWS_AUTH = "true";
+
+    private final Settings settings;
+    private final SystemUtilsWrapper systemUtilsWrapper;
+
+    public LdapExtensions(Settings settings) {
+        this(settings, new SystemUtilsWrapper());
+    }
+
+    LdapExtensions(Settings settings, SystemUtilsWrapper systemUtilsWrapper) {
+        this.settings = settings;
+        this.systemUtilsWrapper = systemUtilsWrapper;
+    }
+
+    @Override
+    public Object provide() {
+        return getExtensions();
+    }
+
+    List<Class> getExtensions() {
+        List<Class> extensions = Lists.newArrayList();
+        if (isWindowsAuthEnabled()) {
+            if (systemUtilsWrapper.isOperatingSystemWindows()) {
+                extensions.add(WindowsSecurityRealm.class);
+            } else {
+                throw new IllegalArgumentException(
+                        String.format("Windows authentication is enabled, while the OS is not Windows."));
+            }
+        } else {
+            extensions.add(LdapRealm.class);
+            extensions.add(LdapSettingsManager.class);
+            extensions.add(LdapAutodiscovery.class);
+        }
+        return extensions;
+    }
+
+    boolean isWindowsAuthEnabled() {
+        boolean isWindowsAuthEnabled;
+        if (systemUtilsWrapper.isOperatingSystemWindows()) {
+            // In Windows OS, Windows authentication is enabled by default.
+            isWindowsAuthEnabled = Boolean.parseBoolean(StringUtils.defaultString(settings.getString(SONAR_LDAP_WINDOWS_AUTH),
+                    DEFAULT_SONAR_LDAP_WINDOWS_AUTH));
+        } else {
+            isWindowsAuthEnabled = settings.getBoolean(SONAR_LDAP_WINDOWS_AUTH);
+        }
+
+        return isWindowsAuthEnabled;
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/SystemUtilsWrapper.java
+++ b/src/main/java/org/sonar/plugins/ldap/SystemUtilsWrapper.java
@@ -19,17 +19,13 @@
  */
 package org.sonar.plugins.ldap;
 
-import com.google.common.collect.ImmutableList;
-import java.util.List;
-import org.sonar.api.SonarPlugin;
+import org.apache.commons.lang.SystemUtils;
 
 /**
- * @author Evgeny Mandrikov
+ * Wrapper class for accessing SystemUtils APIs
  */
-public class LdapPlugin extends SonarPlugin {
-
-  public List getExtensions() {
-    return ImmutableList.of(LdapExtensions.class);
-  }
-
+public class SystemUtilsWrapper {
+    public boolean isOperatingSystemWindows(){
+        return SystemUtils.IS_OS_WINDOWS;
+    }
 }

--- a/src/main/java/org/sonar/plugins/ldap/windows/Win32PlatformWrapper.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/Win32PlatformWrapper.java
@@ -1,0 +1,49 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.windows;
+
+import com.sun.jna.platform.win32.Advapi32;
+import com.sun.jna.platform.win32.Advapi32Util;
+import com.sun.jna.platform.win32.Netapi32Util;
+import com.sun.jna.platform.win32.WinNT;
+
+/**
+ * Wrapper class over Win32 APIs
+ */
+public class Win32PlatformWrapper {
+    public boolean logonUser(final String username, final String domain, final String password,
+                             final int logonType, final int logonProvider, WinNT.HANDLEByReference pHandleUser) {
+        return Advapi32.INSTANCE.LogonUser(username, domain, password, logonType, logonProvider, pHandleUser);
+    }
+
+    public boolean logonUser(final String username, final String domain, final String password,
+                             final int logonType, final int logonProvider) {
+        WinNT.HANDLEByReference pHandleUser = new WinNT.HANDLEByReference();
+        return logonUser(username, domain, password, logonType, logonProvider, pHandleUser);
+    }
+
+    public Advapi32Util.Account getAccountByName(final String systemName, final String userName) {
+        return Advapi32Util.getAccountByName(systemName, userName);
+    }
+
+    public Netapi32Util.Group[] getUserGroups(final String userAlias, final String domainName) {
+        return Netapi32Util.getUserGroups(userAlias, domainName);
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/windows/Win32PlatformWrapper.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/Win32PlatformWrapper.java
@@ -19,10 +19,7 @@
  */
 package org.sonar.plugins.ldap.windows;
 
-import com.sun.jna.platform.win32.Advapi32;
-import com.sun.jna.platform.win32.Advapi32Util;
-import com.sun.jna.platform.win32.Netapi32Util;
-import com.sun.jna.platform.win32.WinNT;
+import com.sun.jna.platform.win32.*;
 
 /**
  * Wrapper class over Win32 APIs
@@ -45,5 +42,10 @@ public class Win32PlatformWrapper {
 
     public Netapi32Util.Group[] getUserGroups(final String userAlias, final String domainName) {
         return Netapi32Util.getUserGroups(userAlias, domainName);
+    }
+
+    public String getLastErrorMessage() {
+        WinNT.HRESULT hr = W32Errors.HRESULT_FROM_WIN32(Kernel32.INSTANCE.GetLastError());
+        return Kernel32Util.formatMessage(hr);
     }
 }

--- a/src/main/java/org/sonar/plugins/ldap/windows/WindowsAccount.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/WindowsAccount.java
@@ -1,0 +1,64 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.windows;
+
+import com.sun.jna.platform.win32.Advapi32Util;
+import org.apache.commons.lang.NullArgumentException;
+
+/**
+ * Windows account
+ */
+public class WindowsAccount {
+    private final Advapi32Util.Account account;
+
+    public WindowsAccount(final Advapi32Util.Account account) {
+        if (account == null) {
+            throw new NullArgumentException("account");
+        }
+        this.account = account;
+    }
+
+    /**
+     * Account's domain-name
+     *
+     * @return {@link String}
+     */
+    public String getDomainName() {
+        return account.domain;
+    }
+
+    /**
+     * Account's user name
+     *
+     * @return {@link String}
+     */
+    public String getUserName() {
+        return account.name;
+    }
+
+    /**
+     * Account's fully qualified name
+     *
+     * @return {@link String}
+     */
+    public String getFqn() {
+        return account.fqn;
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelper.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelper.java
@@ -66,8 +66,7 @@ public class WindowsAuthenticationHelper {
                     windowsAccount.getDomainName(), password, WinBase.LOGON32_LOGON_NETWORK,
                     WinBase.LOGON32_PROVIDER_DEFAULT);
             if (!isUserAuthenticated) {
-                WinNT.HRESULT hr = W32Errors.HRESULT_FROM_WIN32(Kernel32.INSTANCE.GetLastError());
-                LOG.debug("User {} is not authenticated : {}", userName, Kernel32Util.formatMessage(hr));
+                LOG.debug("User {} is not authenticated : {}", userName, win32PlatformWrapper.getLastErrorMessage());
             }
         }
 

--- a/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelper.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelper.java
@@ -1,0 +1,154 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.windows;
+
+import com.sun.jna.platform.win32.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.security.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class WindowsAuthenticationHelper {
+    private static final Logger LOG = LoggerFactory.getLogger(WindowsAuthenticationHelper.class);
+    private Win32PlatformWrapper win32PlatformWrapper;
+
+    public WindowsAuthenticationHelper() {
+        this(new Win32PlatformWrapper());
+    }
+
+    WindowsAuthenticationHelper(Win32PlatformWrapper win32PlatformWrapper) {
+        this.win32PlatformWrapper = win32PlatformWrapper;
+    }
+
+    /**
+     * Authenticates the user using the provided username and password
+     *
+     * @param userName Username of the user. Should be in domain\\user format
+     * @param password Password of the user
+     * @return Returns true if user is authenticated successfully, otherwise returns false.
+     */
+    public boolean logonUser(final String userName, final String password) {
+        if (userName == null || userName.isEmpty()) {
+            throw new IllegalArgumentException("username is null or empty");
+        }
+
+        if (password == null || password.isEmpty()) {
+            throw new IllegalArgumentException("password is null or empty");
+        }
+
+        boolean isUserAuthenticated = false;
+
+        WindowsAccount windowsAccount = lookupAccount(userName);
+        if (windowsAccount != null) {
+            // Logon to the local machine using the default logon provider: Negotiate and NTLM
+            isUserAuthenticated = win32PlatformWrapper.logonUser(windowsAccount.getUserName(),
+                    windowsAccount.getDomainName(), password, WinBase.LOGON32_LOGON_NETWORK,
+                    WinBase.LOGON32_PROVIDER_DEFAULT);
+            if (!isUserAuthenticated) {
+                WinNT.HRESULT hr = W32Errors.HRESULT_FROM_WIN32(Kernel32.INSTANCE.GetLastError());
+                LOG.debug("User {} is not authenticated : {}", userName, Kernel32Util.formatMessage(hr));
+            }
+        }
+
+        return isUserAuthenticated;
+    }
+
+    /**
+     * Fetches the group information for the given domain user. Note that it doesn't fetch the groups information
+     * across domains in the forest.
+     *
+     * @param userName The username of the user. Should be in domain\\user format.
+     * @return {@link Collection} of domain groups of which the user is part of.
+     */
+    public Collection<String> getGroups(final String userName) {
+        if (userName == null || userName.isEmpty()) {
+            throw new IllegalArgumentException("userName should not be null or empty");
+        }
+        Collection<String> groups = new ArrayList<String>();
+
+        WindowsAccount windowsAccount = lookupAccount(userName);
+        if (windowsAccount != null) {
+            Netapi32Util.Group[] userGroups = win32PlatformWrapper.getUserGroups(windowsAccount.getUserName(), windowsAccount.getDomainName());
+            if (userGroups != null) {
+                for (int i = 0; i < userGroups.length; i++) {
+                    String group = windowsAccount.getDomainName() + "\\" + userGroups[i].name;
+                    groups.add(group.toLowerCase());
+                }
+            }
+        }
+
+        return groups;
+    }
+
+    /**
+     * Gets the {@link UserDetails} for the given domain user.
+     *
+     * @param userName The user name of the user. Should be in domain\\user format
+     * @return {@link UserDetails} for the given domain user
+     */
+    public UserDetails getUserDetails(final String userName) {
+        if (userName == null || userName.isEmpty()) {
+            throw new IllegalArgumentException("userName is null or empty.");
+        }
+
+        UserDetails userDetails = null;
+
+        WindowsAccount windowsAccount = lookupAccount(userName);
+        if (windowsAccount != null) {
+            userDetails = new UserDetails();
+            // Setting the name to User's Fully qualified Name
+            userDetails.setName(windowsAccount.getFqn());
+            // Not getting Email for the user
+        }
+
+        return userDetails;
+    }
+
+    private WindowsAccount lookupAccount(final String userName) {
+        WindowsAccount windowsAccount = null;
+
+        if (isValidUserNamePattern(userName)) {
+            try {
+                Advapi32Util.Account account = win32PlatformWrapper.getAccountByName(null, userName);
+                if (account != null) {
+                    windowsAccount = new WindowsAccount(account);
+                } else {
+                    LOG.debug("User {} is not found.", userName);
+                }
+            } catch (Win32Exception e) {
+                LOG.debug("User {} is not found: {}", userName, e.getMessage());
+            }
+        } else {
+            LOG.debug("Invalid user-name format for the user: {}. Expected format: domain\\user.", userName);
+        }
+
+        return windowsAccount;
+    }
+
+    private boolean isValidUserNamePattern(final String userName) {
+        Pattern userNamePattern = Pattern.compile("(\\w+)\\\\(\\w+)");
+        Matcher parts = userNamePattern.matcher(userName);
+        return parts.matches();
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticator.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticator.java
@@ -1,0 +1,64 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.windows;
+
+import org.apache.commons.lang.NullArgumentException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.security.LoginPasswordAuthenticator;
+
+public class WindowsAuthenticator implements LoginPasswordAuthenticator {
+    private static final Logger LOG = LoggerFactory.getLogger(WindowsAuthenticator.class);
+    private final WindowsAuthenticationHelper windowsAuthenticationHelper;
+
+    public WindowsAuthenticator(WindowsAuthenticationHelper windowsAuthenticationHelper) {
+        if (windowsAuthenticationHelper == null) {
+            throw new NullArgumentException("windowsAuthenticationHelper");
+        }
+        this.windowsAuthenticationHelper = windowsAuthenticationHelper;
+    }
+
+    @Override
+    public void init() {
+        // nothing to do
+    }
+
+    /**
+     * Authenticates the user using Windows LogonUser API
+     *
+     * @param userName The username to use.
+     * @param password The password to use.
+     */
+    @Override
+    public boolean authenticate(final String userName, final String password) {
+        if (userName == null || userName.isEmpty()) {
+            LOG.debug("Username is blank.");
+            return false;
+        }
+
+        if (password == null || password.isEmpty()) {
+            LOG.debug("Password is blank.");
+            return false;
+        }
+
+        LOG.debug("Authenticating user: {}", userName);
+        return windowsAuthenticationHelper.logonUser(userName, password);
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/windows/WindowsGroupsProvider.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/WindowsGroupsProvider.java
@@ -1,0 +1,55 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.windows;
+
+import org.apache.commons.lang.NullArgumentException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.security.ExternalGroupsProvider;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class WindowsGroupsProvider extends ExternalGroupsProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(WindowsGroupsProvider.class);
+
+    private final WindowsAuthenticationHelper windowsAuthenticationHelper;
+
+    public WindowsGroupsProvider(WindowsAuthenticationHelper windowsAuthenticationHelper) {
+        if (windowsAuthenticationHelper == null) {
+            throw new NullArgumentException("windowsAuthenticationHelper");
+        }
+        this.windowsAuthenticationHelper = windowsAuthenticationHelper;
+    }
+
+    /**
+     * @return A {@link Collection} of groups for specified user
+     */
+    @Override
+    public Collection<String> doGetGroups(final String userName) {
+        if (userName == null || userName.isEmpty()) {
+            LOG.debug("Username is blank.");
+            return new ArrayList<String>();
+        }
+        LOG.debug("Requesting groups for user: {}", userName);
+
+        return windowsAuthenticationHelper.getGroups(userName);
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/windows/WindowsSecurityRealm.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/WindowsSecurityRealm.java
@@ -1,0 +1,60 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.windows;
+
+import org.sonar.api.security.*;
+
+public class WindowsSecurityRealm extends SecurityRealm {
+
+    // Keeping the Realm's NAME as "LDAP" to avoid having different realm name for the same plugin
+    protected static final String NAME = "LDAP";
+
+    private final WindowsAuthenticator windowsAuthenticator;
+    private final WindowsUsersProvider windowsUsersProvider;
+    private final WindowsGroupsProvider windowsGroupsProvider;
+
+    public WindowsSecurityRealm() {
+        WindowsAuthenticationHelper windowsAuthenticationHelper = new WindowsAuthenticationHelper();
+
+        this.windowsAuthenticator = new WindowsAuthenticator(windowsAuthenticationHelper);
+        this.windowsUsersProvider = new WindowsUsersProvider(windowsAuthenticationHelper);
+        this.windowsGroupsProvider = new WindowsGroupsProvider(windowsAuthenticationHelper);
+    }
+
+    @Override
+    public LoginPasswordAuthenticator getLoginPasswordAuthenticator() {
+        return windowsAuthenticator;
+    }
+
+    @Override
+    public ExternalUsersProvider getUsersProvider() {
+        return windowsUsersProvider;
+    }
+
+    @Override
+    public ExternalGroupsProvider getGroupsProvider() {
+        return windowsGroupsProvider;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+}

--- a/src/main/java/org/sonar/plugins/ldap/windows/WindowsUsersProvider.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/WindowsUsersProvider.java
@@ -1,0 +1,52 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.windows;
+
+import org.apache.commons.lang.NullArgumentException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.security.ExternalUsersProvider;
+import org.sonar.api.security.UserDetails;
+
+public class WindowsUsersProvider extends ExternalUsersProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(WindowsUsersProvider.class);
+    private final WindowsAuthenticationHelper windowsAuthenticationHelper;
+
+    public WindowsUsersProvider(WindowsAuthenticationHelper windowsAuthenticationHelper) {
+        if (windowsAuthenticationHelper == null) {
+            throw new NullArgumentException("windowsAuthenticationHelper");
+        }
+        this.windowsAuthenticationHelper = windowsAuthenticationHelper;
+    }
+
+    /**
+     * @return details for the specified user, or null if the user doesn't exist
+     */
+    @Override
+    public UserDetails doGetUserDetails(final String userName) {
+        if (userName == null || userName.isEmpty()) {
+            LOG.debug("Username is blank.");
+            return null;
+        }
+        LOG.debug("Requesting details for user: {}", userName);
+
+        return windowsAuthenticationHelper.getUserDetails(userName);
+    }
+}

--- a/src/test/java/org/sonar/plugins/ldap/LdapExtensionsTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/LdapExtensionsTest.java
@@ -1,0 +1,122 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.sonar.api.config.Settings;
+import org.sonar.plugins.ldap.windows.WindowsSecurityRealm;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LdapExtensionsTest {
+    @Test
+    public void provideTests() {
+        Settings settings = new Settings();
+        LdapExtensions ldapExtensions = new LdapExtensions(settings);
+
+        Object ldapExtensionsObject = ldapExtensions.provide();
+        assertThat(ldapExtensionsObject).isNotNull();
+    }
+
+    @Test
+    public void getExtensionsDefaultOnWindowsTests() {
+        this.runGetExtensionsDefaultTest(true, this.getExpectedWindowsExtensions());
+    }
+
+    @Test
+    public void getExtensionsDefaultOnNonWindowsOsTests() {
+        this.runGetExtensionsDefaultTest(false, this.getExpectedLdapExtensions());
+    }
+
+    @Test
+    public void getExtensionsForWindowsSecurity() {
+        this.runGetExtensionsTest("true", true, this.getExpectedWindowsExtensions());
+    }
+
+    @Test
+    public void getExtensionsForLdapRealm() {
+        this.runGetExtensionsTest("ldap", false, this.getExpectedLdapExtensions());
+        this.runGetExtensionsTest("", false, this.getExpectedLdapExtensions());
+        this.runGetExtensionsTest(null, false, this.getExpectedLdapExtensions());
+        this.runGetExtensionsTest("", true, this.getExpectedLdapExtensions());
+        this.runGetExtensionsTest(null, true, this.getExpectedWindowsExtensions());
+        this.runGetExtensionsTest("ldap", true, this.getExpectedLdapExtensions());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getExtensionsThrowsException() {
+        Settings settings = new Settings();
+        settings.setProperty(LdapExtensions.SONAR_LDAP_WINDOWS_AUTH, "true");
+        SystemUtilsWrapper systemUtilsWrapper = Mockito.mock(SystemUtilsWrapper.class);
+        Mockito.when(systemUtilsWrapper.isOperatingSystemWindows()).thenReturn(false);
+
+        LdapExtensions ldapExtensions = new LdapExtensions(settings, systemUtilsWrapper);
+
+        ldapExtensions.getExtensions();
+    }
+
+    private void runGetExtensionsDefaultTest(boolean isOperatingSystemWindows, List<Class> expectedExtensions) {
+        Settings settings = new Settings();
+        SystemUtilsWrapper systemUtilsWrapper = Mockito.mock(SystemUtilsWrapper.class);
+        Mockito.when(systemUtilsWrapper.isOperatingSystemWindows()).thenReturn(isOperatingSystemWindows);
+        LdapExtensions ldapExtensions = new LdapExtensions(settings, systemUtilsWrapper);
+
+        List<Class> extensions = ldapExtensions.getExtensions();
+
+        assertThat(extensions).isNotNull();
+        assertThat(CollectionUtils.isEqualCollection(extensions, expectedExtensions)).isTrue();
+    }
+
+    private void runGetExtensionsTest(String windowsAuthSettingValue, boolean isOperatingSystemWindows, List<Class> expectedExtensions) {
+        Settings settings = new Settings();
+        settings.setProperty(LdapExtensions.SONAR_LDAP_WINDOWS_AUTH, windowsAuthSettingValue);
+
+        SystemUtilsWrapper systemUtilsWrapper = Mockito.mock(SystemUtilsWrapper.class);
+        Mockito.when(systemUtilsWrapper.isOperatingSystemWindows()).thenReturn(isOperatingSystemWindows);
+
+        LdapExtensions ldapExtensions = new LdapExtensions(settings, systemUtilsWrapper);
+
+        List<Class> extensions = ldapExtensions.getExtensions();
+
+        assertThat(extensions).isNotNull();
+        assertThat(CollectionUtils.isEqualCollection(extensions, expectedExtensions)).isTrue();
+    }
+
+    private List<Class> getExpectedLdapExtensions() {
+        List<Class> expectedExtensions = new ArrayList<Class>();
+        expectedExtensions.add(LdapRealm.class);
+        expectedExtensions.add(LdapSettingsManager.class);
+        expectedExtensions.add(LdapAutodiscovery.class);
+
+        return expectedExtensions;
+    }
+
+    private List<Class> getExpectedWindowsExtensions() {
+        List<Class> expectedExtensions = new ArrayList<Class>();
+        expectedExtensions.add(WindowsSecurityRealm.class);
+
+        return expectedExtensions;
+    }
+}

--- a/src/test/java/org/sonar/plugins/ldap/windows/WindowsAccountTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/windows/WindowsAccountTest.java
@@ -1,0 +1,46 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.windows;
+
+import com.sun.jna.platform.win32.Advapi32Util;
+import org.apache.commons.lang.NullArgumentException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WindowsAccountTest {
+
+    @Test(expected = NullArgumentException.class)
+    public void nullArgumentCheckOnConstructor() {
+        WindowsAccount windowsAccount = new WindowsAccount(null);
+    }
+
+    public void windowsAccountConstructorTest() {
+        Advapi32Util.Account account = new Advapi32Util.Account();
+        account.name = "name";
+        account.domain = "domain";
+        account.fqn = "domain\\name";
+
+        WindowsAccount windowsAccount = new WindowsAccount(account);
+        assertThat(windowsAccount.getUserName()).isEqualTo(account.name);
+        assertThat(windowsAccount.getDomainName()).isEqualTo(account.domain);
+        assertThat(windowsAccount.getFqn()).isEqualTo(account.fqn);
+    }
+}

--- a/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelperTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelperTest.java
@@ -1,0 +1,335 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.windows;
+
+import com.sun.jna.platform.win32.Advapi32Util;
+import com.sun.jna.platform.win32.Netapi32Util;
+import com.sun.jna.platform.win32.Win32Exception;
+import com.sun.jna.platform.win32.WinBase;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.sonar.api.security.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WindowsAuthenticationHelperTest {
+    private WindowsAuthenticationHelper authenticationHelper;
+
+    @Before
+    public void initialize() {
+        authenticationHelper = new WindowsAuthenticationHelper();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void logonUserNullCheckUserName() {
+        authenticationHelper.logonUser(null, "secret");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void logonUserNullCheckPassword() {
+        authenticationHelper.logonUser("user", null);
+    }
+
+    @Test
+    public void logonUserForInvalidUserNameFormatTests() {
+        runLogonUserTest(null, "\\", "", "secret", false, false, false);
+        runLogonUserTest(null, "\\", null, "secret", false, false, false);
+        runLogonUserTest("", "\\", null, "secret", false, false, false);
+        runLogonUserTest("", "\\", "", "secret", false, false, false);
+        runLogonUserTest("user", "@", "domain", "secret", false, false, false);
+        runLogonUserTest("user@domain", "", "", "secret", false, false, false);
+        runLogonUserTest("domain", "\\", "user\\other-format", "secret", false, false, false);
+    }
+
+    @Test
+    public void logonUserForValidUserNameTests() {
+        runLogonUserTest("domain", "\\", "user", "secret", true, true, true);
+        runLogonUserTest("domain", "\\", "user", "invalid-secret", true, true, false);
+    }
+
+    @Test
+    public void logonUserWhenAccountLookupReturnsNull() {
+        runLogonUserTest("domain", "\\", "invalidUser", "secret", true, false, false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getGroupsNullArgumentCheck() {
+        authenticationHelper.getGroups(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getGroupsBlankArgumentCheck() {
+        authenticationHelper.getGroups("");
+    }
+
+    @Test
+    public void getGroupsInvalidUserName() {
+        runGetGroupsTest(null, "\\", "", false, false, null);
+        runGetGroupsTest(null, "\\", null, false, false, null);
+        runGetGroupsTest("", "\\", null, false, false, null);
+        runGetGroupsTest("", "\\", "", false, false, null);
+        runGetGroupsTest("user", "@", "domain", false, false, null);
+        runGetGroupsTest("user@domain", "", "", false, false, null);
+        runGetGroupsTest("domain", "\\", "user\\other-format", false, false, null);
+    }
+
+    @Test
+    public void getGroupsWhenAccountLookupReturnsNull() {
+        runGetGroupsTest("domain", "\\", "otherUser", true, false, null);
+    }
+
+    @Test
+    public void getGroupsForValidUserNameTests() {
+
+        DomainGroup domainGroup1 = new DomainGroup();
+        domainGroup1.setDomainName("Domain1");
+        domainGroup1.setGroupName("Group1");
+
+        DomainGroup domainGroup2 = new DomainGroup();
+        domainGroup2.setDomainName("Domain1");
+        domainGroup2.setGroupName("Group2");
+
+        DomainGroup[] userWithNoDomainGroup = new DomainGroup[]{};
+        DomainGroup[] userWithOneDomainGroup = new DomainGroup[]{domainGroup1};
+        DomainGroup[] userWithTwoDomainGroups = new DomainGroup[]{domainGroup1, domainGroup2};
+
+        runGetGroupsTest("Domain1", "\\", "userWithNoDomainGroup", true, true, userWithNoDomainGroup);
+        runGetGroupsTest("Domain1", "\\", "userWithOneGroup", true, true, userWithOneDomainGroup);
+        runGetGroupsTest("Domain1", "\\", "userWithTwoDomainGroups", true, true, userWithTwoDomainGroups);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getUserDetailsNullCheck() {
+        WindowsAuthenticationHelper authenticationHelper = new WindowsAuthenticationHelper();
+        authenticationHelper.getUserDetails(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getUserDetailsEmptyCheck() {
+        WindowsAuthenticationHelper authenticationHelper = new WindowsAuthenticationHelper();
+        authenticationHelper.getUserDetails("");
+    }
+
+    @Test
+    public void getUserDetailsForValidUserNamePatternTests() {
+        runGetUserDetailsForValidUserNameTest("domain\\user", "domain\\user");
+        runGetUserDetailsForValidUserNameTest("domain\\invalidUser", null);
+    }
+
+    @Test
+    public void getUserDetailsWhenGetAccountByNameThrowsExceptionTest() {
+        Win32PlatformWrapper win32PlatformWrapper = Mockito.mock(Win32PlatformWrapper.class);
+        Mockito.when(win32PlatformWrapper.getAccountByName(null, "domain\\userName")).thenThrow(new Win32Exception(0));
+
+        WindowsAuthenticationHelper authenticationHelper = new WindowsAuthenticationHelper(win32PlatformWrapper);
+
+        assertThat(authenticationHelper.getUserDetails("domain\\userName")).isNull();
+        Mockito.verify(win32PlatformWrapper, Mockito.never()).getUserGroups("domain", "userName");
+        Mockito.verify(win32PlatformWrapper, Mockito.times(1)).getAccountByName(null, "domain\\userName");
+    }
+
+    @Test
+    public void getUserDetailsWhenGetAccountByNameReturnsNullTest() {
+        Win32PlatformWrapper win32PlatformWrapper = Mockito.mock(Win32PlatformWrapper.class);
+        Mockito.when(win32PlatformWrapper.getAccountByName(null, "domain\\userName")).thenReturn(null);
+
+        WindowsAuthenticationHelper authenticationHelper = new WindowsAuthenticationHelper(win32PlatformWrapper);
+
+        assertThat(authenticationHelper.getUserDetails("domain\\userName")).isNull();
+        Mockito.verify(win32PlatformWrapper, Mockito.never()).getUserGroups("domain", "userName");
+        Mockito.verify(win32PlatformWrapper, Mockito.times(1)).getAccountByName(null, "domain\\userName");
+    }
+
+    private static void runLogonUserTest(final String domainName, final String userDomainNameSeparator,
+                                         final String userName, final String password, boolean isUserNameFormatValid,
+                                         boolean isUserValid, boolean expectedIsUserAuthenticated) {
+        // Parameters consistency check
+        assertThat(!isUserNameFormatValid && isUserValid).isFalse();
+
+        String userNameWithDomain = getUserNameWithDomain(domainName, userDomainNameSeparator, userName);
+        int expectedInvocationCountGetAccountByName = 0;
+        int expectedInvocationCountLogonUser = 0;
+        Advapi32Util.Account account = null;
+        if (isUserNameFormatValid && isUserValid) {
+            account = new Advapi32Util.Account();
+            account.domain = domainName;
+            account.name = userName;
+            account.fqn = userNameWithDomain;
+        }
+
+        if (isUserNameFormatValid) {
+            expectedInvocationCountGetAccountByName = 1;
+        }
+        if (isUserValid) {
+            expectedInvocationCountLogonUser = 1;
+        }
+
+        Win32PlatformWrapper win32PlatformWrapper = Mockito.mock(Win32PlatformWrapper.class);
+        Mockito.when(win32PlatformWrapper.logonUser(userName, domainName, password, WinBase.LOGON32_LOGON_NETWORK,
+                WinBase.LOGON32_PROVIDER_DEFAULT)).thenReturn(expectedIsUserAuthenticated);
+        Mockito.when(win32PlatformWrapper.getAccountByName(null, userNameWithDomain)).thenReturn(account);
+        WindowsAuthenticationHelper authenticationHelper = new WindowsAuthenticationHelper(win32PlatformWrapper);
+
+        assertThat(authenticationHelper.logonUser(getUserNameWithDomain(domainName, userDomainNameSeparator, userName),
+                password)).isEqualTo(expectedIsUserAuthenticated);
+
+
+        Mockito.verify(win32PlatformWrapper, Mockito.times(expectedInvocationCountLogonUser)).
+                logonUser(userName, domainName, password, WinBase.LOGON32_LOGON_NETWORK, WinBase.LOGON32_PROVIDER_DEFAULT);
+        Mockito.verify(win32PlatformWrapper, Mockito.times(expectedInvocationCountGetAccountByName)).
+                getAccountByName(null, userNameWithDomain);
+    }
+
+    private static String getUserNameWithDomain(final String domainName, final String separator, final String userName) {
+        String userNameWithDomain = "";
+        if (domainName != null) {
+            userNameWithDomain = domainName;
+        }
+        if (separator != null) {
+            userNameWithDomain += separator;
+        }
+        if (userName != null) {
+            userNameWithDomain += userName;
+        }
+
+        return userNameWithDomain;
+    }
+
+    private static Collection<String> getUserGroups(DomainGroup[] domainGroups) {
+        Collection<String> userGroups = new ArrayList<String>();
+        if (domainGroups != null) {
+            for (DomainGroup domainGroup : domainGroups) {
+                String group = domainGroup.getDomainName() + "\\" + domainGroup.getGroupName();
+                userGroups.add(group.toLowerCase());
+            }
+        }
+        return userGroups;
+    }
+
+    private static void runGetGroupsTest(final String domainName, final String separator, final String userAlias,
+                                         boolean isUserNameFormatValid, boolean isUserValid,
+                                         DomainGroup[] domainGroups) {
+        // Parameters consistency check
+        assertThat(!isUserNameFormatValid && isUserValid).isFalse();
+
+        int expectedInvocationCountGetAccountByName = 0;
+        int expectedInvocationCountGetGroups = 0;
+        if (isUserNameFormatValid) {
+            expectedInvocationCountGetAccountByName = 1;
+        }
+        if (isUserValid) {
+            expectedInvocationCountGetGroups = 1;
+        }
+
+        Collection<String> expectedUserGroups = getUserGroups(domainGroups);
+        String userNameWithDomain = getUserNameWithDomain(domainName, separator, userAlias);
+        Advapi32Util.Account account = null;
+        if (isUserNameFormatValid && isUserValid) {
+            account = new Advapi32Util.Account();
+            account.domain = domainName;
+            account.name = userAlias;
+            account.fqn = userNameWithDomain;
+        }
+
+        Win32PlatformWrapper win32PlatformWrapper = Mockito.mock(Win32PlatformWrapper.class);
+        Mockito.when(win32PlatformWrapper.getUserGroups(userAlias, domainName)).
+                thenReturn(getNetApi32UtilGroups(domainGroups));
+        Mockito.when(win32PlatformWrapper.getAccountByName(null, userNameWithDomain)).thenReturn(account);
+
+        WindowsAuthenticationHelper authenticationHelper = new WindowsAuthenticationHelper(win32PlatformWrapper);
+        Collection<String> actualUserGroups = authenticationHelper.getGroups(userNameWithDomain);
+
+        assertThat(CollectionUtils.isEqualCollection(actualUserGroups, expectedUserGroups)).isTrue();
+        Mockito.verify(win32PlatformWrapper, Mockito.times(expectedInvocationCountGetAccountByName)).
+                getAccountByName(null, userNameWithDomain);
+        Mockito.verify(win32PlatformWrapper, Mockito.times(expectedInvocationCountGetGroups)).
+                getUserGroups(userAlias, domainName);
+    }
+
+    private static Netapi32Util.Group[] getNetApi32UtilGroups(DomainGroup[] domainGroups) {
+        if (domainGroups != null) {
+            Netapi32Util.Group[] groups = new Netapi32Util.Group[domainGroups.length];
+            for (int i = 0; i < domainGroups.length; i++) {
+                Netapi32Util.Group netapi32UtilGroup = new Netapi32Util.Group();
+                netapi32UtilGroup.name = domainGroups[i].getGroupName();
+
+                groups[i] = netapi32UtilGroup;
+            }
+            return groups;
+        }
+
+        return null;
+    }
+
+    private static void runGetUserDetailsForValidUserNameTest(String userName, String expectedFqn) {
+        Advapi32Util.Account account = null;
+        if (expectedFqn != null && !expectedFqn.isEmpty()) {
+            account = new Advapi32Util.Account();
+            account.fqn = expectedFqn;
+        }
+
+        Win32PlatformWrapper win32PlatformWrapper = Mockito.mock(Win32PlatformWrapper.class);
+        Mockito.when(win32PlatformWrapper.getAccountByName(null, userName)).thenReturn(account);
+
+        WindowsAuthenticationHelper authenticationHelper = new WindowsAuthenticationHelper(win32PlatformWrapper);
+
+        UserDetails expectedUserDetails = null;
+        if (expectedFqn != null && !expectedFqn.isEmpty()) {
+            expectedUserDetails = new UserDetails();
+            expectedUserDetails.setName(expectedFqn);
+        }
+
+        UserDetails userDetails = authenticationHelper.getUserDetails(userName);
+
+        if (StringUtils.isBlank(expectedFqn)) {
+            assertThat(userDetails).isNull();
+        } else {
+            assertThat(userDetails).isNotNull();
+            assertThat(userDetails).isEqualToComparingFieldByField(expectedUserDetails);
+        }
+    }
+
+    class DomainGroup {
+        private String domainName;
+        private String groupName;
+
+        public String getDomainName() {
+            return domainName;
+        }
+
+        public void setDomainName(String domainName) {
+            this.domainName = domainName;
+        }
+
+        public String getGroupName() {
+            return groupName;
+        }
+
+        public void setGroupName(String groupName) {
+            this.groupName = groupName;
+        }
+    }
+}

--- a/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelperTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelperTest.java
@@ -142,10 +142,13 @@ public class WindowsAuthenticationHelperTest {
     @Test
     public void getUserDetailsWhenGetAccountByNameThrowsExceptionTest() {
         Win32PlatformWrapper win32PlatformWrapper = Mockito.mock(Win32PlatformWrapper.class);
-        Mockito.when(win32PlatformWrapper.getAccountByName(null, "domain\\userName")).thenThrow(new Win32Exception(0));
+        Win32Exception win32Exception = Mockito.mock(Win32Exception.class);
+        Mockito.when(win32Exception.getMessage()).thenReturn("Win32Exception occurred");
+        Mockito.when(win32PlatformWrapper.getAccountByName(null, "domain\\userName")).thenThrow(win32Exception);
 
         WindowsAuthenticationHelper authenticationHelper = new WindowsAuthenticationHelper(win32PlatformWrapper);
 
+        Mockito.verify(win32Exception, Mockito.times(1)).getMessage();
         assertThat(authenticationHelper.getUserDetails("domain\\userName")).isNull();
         Mockito.verify(win32PlatformWrapper, Mockito.never()).getUserGroups("domain", "userName");
         Mockito.verify(win32PlatformWrapper, Mockito.times(1)).getAccountByName(null, "domain\\userName");

--- a/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticatorTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticatorTest.java
@@ -1,0 +1,68 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.windows;
+
+import org.apache.commons.lang.NullArgumentException;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WindowsAuthenticatorTest {
+
+    @Test(expected = NullArgumentException.class)
+    public void constructorNullArgumentCheck() {
+        WindowsAuthenticator authenticator = new WindowsAuthenticator(null);
+    }
+
+    @Test
+    public void authenticateNullOrEmptyArgumentTests() {
+
+        this.runAuthenticateNullOrEmptyArgumentTest(null, null, false);
+        this.runAuthenticateNullOrEmptyArgumentTest("", null, false);
+        this.runAuthenticateNullOrEmptyArgumentTest("user", null, false);
+        this.runAuthenticateNullOrEmptyArgumentTest("user", "", false);
+    }
+
+    @Test
+    public void authenticateNormalTests() {
+        this.runAuthenticateTest("user", "secret", true);
+        this.runAuthenticateTest("user", "invalid secret", false);
+    }
+
+    private void runAuthenticateTest(final String userName, final String password, boolean expectedIsUserAuthenticated) {
+        WindowsAuthenticationHelper windowsAuthenticationHelper = Mockito.mock(WindowsAuthenticationHelper.class);
+        Mockito.when(windowsAuthenticationHelper.logonUser(userName, password)).thenReturn(expectedIsUserAuthenticated);
+        WindowsAuthenticator authenticator = new WindowsAuthenticator(windowsAuthenticationHelper);
+
+        boolean isUserAuthenticated = authenticator.authenticate(userName, password);
+        assertThat(isUserAuthenticated).isEqualTo(expectedIsUserAuthenticated);
+        Mockito.verify(windowsAuthenticationHelper, Mockito.times(1)).logonUser(userName, password);
+    }
+
+    private void runAuthenticateNullOrEmptyArgumentTest(final String userName, final String password, boolean expectedIsUserAuthenticated) {
+        WindowsAuthenticationHelper windowsAuthenticationHelper = Mockito.mock(WindowsAuthenticationHelper.class);
+        WindowsAuthenticator authenticator = new WindowsAuthenticator(windowsAuthenticationHelper);
+
+        boolean isUserAuthenticated = authenticator.authenticate(userName, password);
+        assertThat(isUserAuthenticated).isEqualTo(expectedIsUserAuthenticated);
+        Mockito.verify(windowsAuthenticationHelper, Mockito.never()).logonUser(userName, password);
+    }
+}

--- a/src/test/java/org/sonar/plugins/ldap/windows/WindowsGroupsProviderTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/windows/WindowsGroupsProviderTest.java
@@ -1,0 +1,65 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.windows;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.NullArgumentException;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WindowsGroupsProviderTest {
+
+    @Test(expected = NullArgumentException.class)
+    public void NullArgumentCheck() {
+        WindowsGroupsProvider groupsProvider = new WindowsGroupsProvider(null);
+    }
+
+    @Test
+    public void doGetGroupsTests() {
+        Collection<String> groups = new ArrayList<String>();
+        groups.add("group1");
+
+        this.runDoGetGroupsTest(null, new ArrayList<String>());
+        this.runDoGetGroupsTest("", new ArrayList<String>());
+        this.runDoGetGroupsTest("user", null);
+        this.runDoGetGroupsTest("user", new ArrayList<String>());
+        this.runDoGetGroupsTest("user", groups);
+    }
+
+    private void runDoGetGroupsTest(String userName, Collection<String> expectedGroups) {
+        WindowsAuthenticationHelper windowsAuthenticationHelper = Mockito.mock(WindowsAuthenticationHelper.class);
+        Mockito.when(windowsAuthenticationHelper.getGroups(userName)).thenReturn(expectedGroups);
+        WindowsGroupsProvider groupsProvider = new WindowsGroupsProvider(windowsAuthenticationHelper);
+
+        Collection<String> groups = groupsProvider.doGetGroups(userName);
+
+        if (expectedGroups == null) {
+            assertThat(groups).isNull();
+        } else {
+            assertThat(groups).isNotNull();
+            assertThat(CollectionUtils.isEqualCollection(groups, expectedGroups)).isTrue();
+        }
+    }
+}

--- a/src/test/java/org/sonar/plugins/ldap/windows/WindowsSecurityRealmTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/windows/WindowsSecurityRealmTest.java
@@ -17,19 +17,20 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.ldap;
+package org.sonar.plugins.ldap.windows;
 
-import com.google.common.collect.ImmutableList;
-import java.util.List;
-import org.sonar.api.SonarPlugin;
+import org.junit.Test;
 
-/**
- * @author Evgeny Mandrikov
- */
-public class LdapPlugin extends SonarPlugin {
+import static org.assertj.core.api.Assertions.assertThat;
 
-  public List getExtensions() {
-    return ImmutableList.of(LdapExtensions.class);
-  }
+public class WindowsSecurityRealmTest {
+    @Test
+    public void normal() {
+        WindowsSecurityRealm windowsSecurityRealm = new WindowsSecurityRealm();
 
+        assertThat(windowsSecurityRealm.getName()).isEqualTo("LDAP");
+        assertThat(windowsSecurityRealm.getLoginPasswordAuthenticator()).isInstanceOf(WindowsAuthenticator.class);
+        assertThat(windowsSecurityRealm.getUsersProvider()).isInstanceOf(WindowsUsersProvider.class);
+        assertThat(windowsSecurityRealm.getGroupsProvider()).isInstanceOf(WindowsGroupsProvider.class);
+    }
 }

--- a/src/test/java/org/sonar/plugins/ldap/windows/WindowsUsersProviderTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/windows/WindowsUsersProviderTest.java
@@ -1,0 +1,61 @@
+/*
+ * SonarQube LDAP Plugin
+ * Copyright (C) 2009 SonarSource
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.ldap.windows;
+
+import org.apache.commons.lang.NullArgumentException;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.sonar.api.security.UserDetails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WindowsUsersProviderTest {
+    @Test(expected = NullArgumentException.class)
+    public void nullArgumentCheckOnConstructor() {
+        WindowsUsersProvider usersProvider = new WindowsUsersProvider(null);
+    }
+
+    @Test
+    public void doGetUserDetailsTests() {
+        UserDetails expectedUserDetails = new UserDetails();
+
+        this.runDoGetUserDetailsTest(null, null);
+        this.runDoGetUserDetailsTest("", null);
+        this.runDoGetUserDetailsTest("user", null);
+        this.runDoGetUserDetailsTest("user", expectedUserDetails);
+    }
+
+    private void runDoGetUserDetailsTest(String userName, UserDetails expectedUserDetails) {
+
+        WindowsAuthenticationHelper windowsAuthenticationHelper = Mockito.mock(WindowsAuthenticationHelper.class);
+        Mockito.when(windowsAuthenticationHelper.getUserDetails(userName)).thenReturn(expectedUserDetails);
+
+        WindowsUsersProvider usersProvider = new WindowsUsersProvider(windowsAuthenticationHelper);
+
+        UserDetails userDetails = usersProvider.doGetUserDetails(userName);
+
+        if (expectedUserDetails == null) {
+            assertThat(userDetails).isNull();
+        } else {
+            assertThat(expectedUserDetails).isNotNull();
+            assertThat(expectedUserDetails).isEqualTo(userDetails);
+        }
+    }
+}


### PR DESCRIPTION
Addition of Windows Authentication support to LDAP plugin (https://jira.sonarsource.com/browse/LDAP-37)

1. Added separate Realm WindowsSecurityRealm to provide windows specific implementation of External User Provider, External Groups Provider and and External Authenticator
2. Added unit test for newly added classes.
3. Added thin wrapper around Win32 Platform APIs provided by JNA libraries


Note:
   1. Group Name will be in domain\group-alias format. This is different from the non-windows ldap plugin where it just group names are common names(cn) of groups.
   2. Windows authentication support in LDAP plugin will be enabled only when the plugin is used in Windows OS.

Limitations
   1. Doesn't support authentication and getting groups information for cross forest domain users.(https://jira.sonarsource.com/browse/LDAP-44)
   2. Doesn't fetch email of the user.(https://jira.sonarsource.com/browse/LDAP-43)

Configuration required to be added to sonar.properties to enable windows authentication through LDAP plugin in windows OS:
sonar.security.realm=LDAP

Configuration required to be added to sonar.properties to not use windows authentication  of LDAP Plugin in windows OS:
sonar.security.realm=LDAP
sonar.ldap.windows.auth=false
Followed by other settings for LDAP plugin