### PR TITLE
LDAP-49 : Fix for Com4jException thrown by external users provider

### DIFF
--- a/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelper.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelper.java
@@ -181,8 +181,21 @@ public class WindowsAuthenticationHelper {
   @CheckForNull
   public UserDetails getUserDetails(String userName) {
     checkArgument(isNotEmpty(userName), "userName is null or empty.");
+
+    LOG.debug("Getting details for user: {}", userName);
+    UserDetails userDetails = null;
     IWindowsAccount windowsAccount = getWindowsAccount(userName);
-    return windowsAccount != null ? getSsoUserDetails(windowsAccount) : null;
+    if (windowsAccount != null) {
+      userDetails = getUserDetails(windowsAccount);
+    }
+
+    if (userDetails == null) {
+      LOG.debug("Unable to get details for user {}", userName);
+    } else {
+      LOG.debug("Details for user {}: {}", userName, userDetails);
+    }
+
+    return userDetails;
   }
 
   /**
@@ -208,10 +221,12 @@ public class WindowsAuthenticationHelper {
       }
     }
 
+    LOG.debug("Groups for the user {} : {}", windowsPrincipal.getName(), groups);
+
     return groups;
   }
 
-  UserDetails getSsoUserDetails(IWindowsAccount windowsAccount) {
+  UserDetails getUserDetails(IWindowsAccount windowsAccount) {
     UserDetails userDetails = new UserDetails();
 
     String windowsAccountName = getWindowsAccountName(new WindowsAccount(windowsAccount),

--- a/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelperTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelperTest.java
@@ -450,7 +450,7 @@ public class WindowsAuthenticationHelperTest {
 
     authenticationHelper = new WindowsAuthenticationHelper(windowsAuthSettings, windowsAuthProvider, adConnectionHelper);
 
-    assertThat(authenticationHelper.getSsoUserDetails(windowsAccount)).isEqualToComparingFieldByField(expectedUserDetails);
+    assertThat(authenticationHelper.getUserDetails(windowsAccount)).isEqualToComparingFieldByField(expectedUserDetails);
   }
 
   private void runGetUserGroupsTest(String domainName, String userName, Collection<WindowsAccount> windowsAccounts,


### PR DESCRIPTION
1. AdConnectionHelper now connects to domain LDAP servers instead of
   forest GC ( Global Catalog) servers to get the users details.
2. More logging is added in AdConnectionHelper and
   WindowsAuthenticationHelper
3. More exception handling is added in AdConnectionHelper to
   catch exceptions thrown by Com4j.
4. Unit tests are also updated.

Manual Testing of scenarios ( Compat mode and and non-compat mode
windows authentication )
1. Test on corpnet in which GC servers are available.
2. Testing on private active directory setup in which
a. Two domains in same forest and AD global catalog is not present
  in both the domains. Windows auth for users from both domain to
  SonarQube server in one of the domain.
b. Two domains in the same forest and AD global catalog is present
   for one of the domains. Windows auth for users from both domain to
   SonarQube server in one of the domain.
c. Two domains ( sub-tree of third domain). Windows auth for users from
   both domain to SonarQube server in one of the domain.