### PR TITLE
displayname used instead of cn on userDetails real name value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.sonarsource.ldap</groupId>
   <artifactId>sonar-ldap-plugin</artifactId>
-  <version>1.6-SNAPSHOT</version>
+  <version>1.5.1-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
   <name>SonarQube LDAP Plugin</name>
   <description>Delegates authentication to LDAP</description>

--- a/src/main/java/org/sonar/plugins/ldap/windows/AdConnectionHelper.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/AdConnectionHelper.java
@@ -79,11 +79,6 @@ public class AdConnectionHelper {
    * Attribute for storing common name of a user in an active directory
    */
   public static final String COMMON_NAME_ATTRIBUTE = "cn";
-  
-  /**
-   * Attribute for storing common name of a user in an active directory
-   */
-  public static final String REAL_NAME_ATTRIBUTE = "displayName";
 
   /**
    * Attribute for storing email of a user in an active directory

--- a/src/main/java/org/sonar/plugins/ldap/windows/AdConnectionHelper.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/AdConnectionHelper.java
@@ -79,6 +79,11 @@ public class AdConnectionHelper {
    * Attribute for storing common name of a user in an active directory
    */
   public static final String COMMON_NAME_ATTRIBUTE = "cn";
+  
+  /**
+   * Attribute for storing common name of a user in an active directory
+   */
+  public static final String REAL_NAME_ATTRIBUTE = "displayName";
 
   /**
    * Attribute for storing email of a user in an active directory

--- a/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelper.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelper.java
@@ -235,7 +235,7 @@ public class WindowsAuthenticationHelper {
 
     Map<String, String> adUserDetails = getAdUserDetails(windowsAccount.getDomain(), windowsAccount.getName());
     if (!adUserDetails.isEmpty()) {
-      userDetails.setName(adUserDetails.get(AdConnectionHelper.REAL_NAME_ATTRIBUTE));
+      userDetails.setName(adUserDetails.get(settings.getLdapUserRealNameAttribute()));
       userDetails.setEmail(adUserDetails.get(AdConnectionHelper.MAIL_ATTRIBUTE));
     } else {
       LOG.debug("Unable to get name and email for user: {}", windowsAccount.getFqn());
@@ -272,9 +272,9 @@ public class WindowsAuthenticationHelper {
     return windowsAccount;
   }
 
-  private Map<String, String> getAdUserDetails(String domainName, String name) {
+  private Map<String, String> getAdUserDetails(String domainName, String name) {      
     Collection<String> requestedDetails = new ArrayList<>();
-    requestedDetails.add(AdConnectionHelper.REAL_NAME_ATTRIBUTE);
+    requestedDetails.add(settings.getLdapUserRealNameAttribute());
     requestedDetails.add(AdConnectionHelper.MAIL_ATTRIBUTE);
     return adConnectionHelper.getUserDetails(domainName, name, requestedDetails);
   }

--- a/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelper.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelper.java
@@ -235,7 +235,7 @@ public class WindowsAuthenticationHelper {
 
     Map<String, String> adUserDetails = getAdUserDetails(windowsAccount.getDomain(), windowsAccount.getName());
     if (!adUserDetails.isEmpty()) {
-      userDetails.setName(adUserDetails.get(AdConnectionHelper.COMMON_NAME_ATTRIBUTE));
+      userDetails.setName(adUserDetails.get(AdConnectionHelper.REAL_NAME_ATTRIBUTE));
       userDetails.setEmail(adUserDetails.get(AdConnectionHelper.MAIL_ATTRIBUTE));
     } else {
       LOG.debug("Unable to get name and email for user: {}", windowsAccount.getFqn());
@@ -274,7 +274,7 @@ public class WindowsAuthenticationHelper {
 
   private Map<String, String> getAdUserDetails(String domainName, String name) {
     Collection<String> requestedDetails = new ArrayList<>();
-    requestedDetails.add(AdConnectionHelper.COMMON_NAME_ATTRIBUTE);
+    requestedDetails.add(AdConnectionHelper.REAL_NAME_ATTRIBUTE);
     requestedDetails.add(AdConnectionHelper.MAIL_ATTRIBUTE);
     return adConnectionHelper.getUserDetails(domainName, name, requestedDetails);
   }

--- a/src/main/java/org/sonar/plugins/ldap/windows/auth/WindowsAuthSettings.java
+++ b/src/main/java/org/sonar/plugins/ldap/windows/auth/WindowsAuthSettings.java
@@ -57,7 +57,13 @@ public class WindowsAuthSettings {
    * Setting to specify group-id attribute, which is used by plugin while returning user groups in compatibility mode
    */
   public static final String LDAP_GROUP_ID_ATTRIBUTE = "ldap.group.idAttribute";
+  
+  /**
+   * Settings to specify real name attribute for a user
+   */
+  public static final String LDAP_WINDOWS_USER_REAL_NAME_ATTRIBUTE = LDAP_WINDOWS + ".user.realNameAttribute"; 
 
+  public static final String DEFAULT_USER_REAL_NAME_ATTRIBUTE = "cn";
   public static final String DEFAULT_SONAR_LDAP_WINDOWS_AUTH = "true";
   public static final String DEFAULT_SONAR_WINDOWS_AUTH_SSO_PROTOCOLS = "NTLM";
   public static final boolean DEFAULT_WINDOWS_COMPATIBILITY_MODE = false;
@@ -117,6 +123,13 @@ public class WindowsAuthSettings {
    */
   public String getProtocols() {
     return StringUtils.defaultIfBlank(settings.getString(LDAP_WINDOWS_AUTH_SSO_PROTOCOLS), DEFAULT_SONAR_WINDOWS_AUTH_SSO_PROTOCOLS);
+  }
+  
+  /**
+   * Returns the specified value for the real name attribute. By default, it's value is "cn"
+   */
+  public String getLdapUserRealNameAttribute(){ 
+      return StringUtils.defaultIfBlank(settings.getString(LDAP_WINDOWS_USER_REAL_NAME_ATTRIBUTE), DEFAULT_USER_REAL_NAME_ATTRIBUTE ); 
   }
 
 }

--- a/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelperTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelperTest.java
@@ -417,12 +417,12 @@ public class WindowsAuthenticationHelperTest {
     Map<String, String> attributesUserDetails = null;
     if (expectedUserDetails != null) {
       attributesUserDetails = new HashMap<String, String>();
-      attributesUserDetails.put(AdConnectionHelper.COMMON_NAME_ATTRIBUTE, expectedUserDetails.getName());
+      attributesUserDetails.put(AdConnectionHelper.REAL_NAME_ATTRIBUTE, expectedUserDetails.getName());
       attributesUserDetails.put(AdConnectionHelper.MAIL_ATTRIBUTE, expectedUserDetails.getEmail());
     }
 
     Collection<String> attributeNames = new ArrayList<String>();
-    attributeNames.add(AdConnectionHelper.COMMON_NAME_ATTRIBUTE);
+    attributeNames.add(AdConnectionHelper.REAL_NAME_ATTRIBUTE);
     attributeNames.add(AdConnectionHelper.MAIL_ATTRIBUTE);
     Mockito.when(adConnectionHelper.getUserDetails(domainName, userName, attributeNames)).thenReturn(attributesUserDetails);
 
@@ -439,12 +439,12 @@ public class WindowsAuthenticationHelperTest {
     Map<String, String> attributesUserDetails = null;
     if (expectedUserDetails != null) {
       attributesUserDetails = new HashMap<String, String>();
-      attributesUserDetails.put(AdConnectionHelper.COMMON_NAME_ATTRIBUTE, expectedUserDetails.getName());
+      attributesUserDetails.put(AdConnectionHelper.REAL_NAME_ATTRIBUTE, expectedUserDetails.getName());
       attributesUserDetails.put(AdConnectionHelper.MAIL_ATTRIBUTE, expectedUserDetails.getEmail());
     }
 
     Collection<String> attributeNames = new ArrayList<>();
-    attributeNames.add(AdConnectionHelper.COMMON_NAME_ATTRIBUTE);
+    attributeNames.add(AdConnectionHelper.REAL_NAME_ATTRIBUTE);
     attributeNames.add(AdConnectionHelper.MAIL_ATTRIBUTE);
     Mockito.when(adConnectionHelper.getUserDetails(windowsAccount.getDomain(), windowsAccount.getName(), attributeNames)).thenReturn(attributesUserDetails);
 

--- a/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelperTest.java
+++ b/src/test/java/org/sonar/plugins/ldap/windows/WindowsAuthenticationHelperTest.java
@@ -403,7 +403,7 @@ public class WindowsAuthenticationHelperTest {
   private static WindowsAuthenticationHelper getWindowsAuthHelperForGetUserDetailsTest(String domainName, String userName,
     boolean doesUserExist, UserDetails expectedUserDetails) {
     IWindowsAuthProvider windowsAuthProvider = mock(IWindowsAuthProvider.class);
-
+    WindowsAuthSettings windowsAuthSettings = new WindowsAuthSettings(new Settings());
     AdConnectionHelper adConnectionHelper = mock(AdConnectionHelper.class);
     String userNameWithDomain = getAccountNameWithDomain(domainName, "\\", userName);
     if (doesUserExist) {
@@ -416,13 +416,13 @@ public class WindowsAuthenticationHelperTest {
 
     Map<String, String> attributesUserDetails = null;
     if (expectedUserDetails != null) {
-      attributesUserDetails = new HashMap<String, String>();
-      attributesUserDetails.put(AdConnectionHelper.REAL_NAME_ATTRIBUTE, expectedUserDetails.getName());
+      attributesUserDetails = new HashMap<>();
+      attributesUserDetails.put(windowsAuthSettings.getLdapUserRealNameAttribute(), expectedUserDetails.getName());
       attributesUserDetails.put(AdConnectionHelper.MAIL_ATTRIBUTE, expectedUserDetails.getEmail());
     }
 
-    Collection<String> attributeNames = new ArrayList<String>();
-    attributeNames.add(AdConnectionHelper.REAL_NAME_ATTRIBUTE);
+    Collection<String> attributeNames = new ArrayList<>();
+    attributeNames.add(windowsAuthSettings.getLdapUserRealNameAttribute());
     attributeNames.add(AdConnectionHelper.MAIL_ATTRIBUTE);
     Mockito.when(adConnectionHelper.getUserDetails(domainName, userName, attributeNames)).thenReturn(attributesUserDetails);
 
@@ -439,12 +439,12 @@ public class WindowsAuthenticationHelperTest {
     Map<String, String> attributesUserDetails = null;
     if (expectedUserDetails != null) {
       attributesUserDetails = new HashMap<String, String>();
-      attributesUserDetails.put(AdConnectionHelper.REAL_NAME_ATTRIBUTE, expectedUserDetails.getName());
+      attributesUserDetails.put(windowsAuthSettings.getLdapUserRealNameAttribute(), expectedUserDetails.getName());
       attributesUserDetails.put(AdConnectionHelper.MAIL_ATTRIBUTE, expectedUserDetails.getEmail());
     }
 
     Collection<String> attributeNames = new ArrayList<>();
-    attributeNames.add(AdConnectionHelper.REAL_NAME_ATTRIBUTE);
+    attributeNames.add(windowsAuthSettings.getLdapUserRealNameAttribute());
     attributeNames.add(AdConnectionHelper.MAIL_ATTRIBUTE);
     Mockito.when(adConnectionHelper.getUserDetails(windowsAccount.getDomain(), windowsAccount.getName(), attributeNames)).thenReturn(attributesUserDetails);
 


### PR DESCRIPTION
This pull-request fixes two minor issues:
- Using displayName as Real Name value on userDetails + fixed tests accordingly
- Fixes version number to 1.5.1 instead of 1.6

E.g. before this fix it was using my logon name, let's say anthonymonori instead of my real name Antal János Monori